### PR TITLE
Rename fen to fen_before and add fen_after in JSON/EDN output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The tool produces a JSON (or EDN) object with three top-level keys:
       "turn": "white",
       "san": "e4",
       "uci": "e2e4",
-      "fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      "fen_before": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      "fen_after": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1",
       "board_img_after":  "<svg ...>"
     },
     ...

--- a/chesstree/json_exporter.py
+++ b/chesstree/json_exporter.py
@@ -202,7 +202,8 @@ class JsonExporter(BaseVisitor[str]):
             "turn": "white" if board.turn == chess.WHITE else "black",
             "san": board.san(move),
             "uci": move.uci(),
-            "fen": board.fen(),
+            "fen_before": board.fen(),
+            "fen_after": fen_after,
         }
         if self.image_fens is None or fen_after in self.image_fens:
             move_entry["board_img_after"] = chess.svg.board(

--- a/tests/test_json_exporter.py
+++ b/tests/test_json_exporter.py
@@ -72,7 +72,8 @@ class TestJsonExporter:
         assert first_move["san"] == "e4"
         assert first_move["turn"] == "white"
         assert first_move["move_number"] == 1
-        assert "fen" in first_move
+        assert "fen_before" in first_move
+        assert "fen_after" in first_move
         assert "uci" in first_move
         assert "board_img_after" in first_move
 


### PR DESCRIPTION
Closes #4

## Changes

Rename `fen` → `fen_before` and add `fen_after` to each move entry in JSON/EDN output.

- **`json_exporter.py`**: `visit_move()` now stores `fen_before` (position before the move, was `fen`) and `fen_after` (resulting position, was already computed but not stored)
- **`test_json_exporter.py`**: Updated assertion to check for both new field names
- **`README.md`**: Updated the JSON example to show both fields

The exporter was already computing `fen_after` (line 198, used for image mode decisions) — this change just stores it in the output and renames the existing field for clarity.

All 204 tests pass.
