### PR TITLE
Simplify NAG encoding to a single code-to-symbol dict

### DIFF
--- a/chesstree/json_exporter.py
+++ b/chesstree/json_exporter.py
@@ -189,8 +189,8 @@ class JsonExporter(BaseVisitor[str]):
     def visit_nag(self, nag: int) -> None:
         if self.comments_flag and self.current_variation:
             if "nags" not in self.current_variation[-1]:
-                self.current_variation[-1]["nags"] = []
-            self.current_variation[-1]["nags"].append({nag: NAG_TO_PGN_STRING.get(nag)})
+                self.current_variation[-1]["nags"] = {}
+            self.current_variation[-1]["nags"][nag] = NAG_TO_PGN_STRING.get(nag)
 
     def visit_move(self, board: chess.Board, move: chess.Move) -> None:
         board_after = board.copy()

--- a/chesstree/json_parser.py
+++ b/chesstree/json_parser.py
@@ -39,10 +39,9 @@ def _process_moves(game_node: chess.pgn.GameNode, moves: List[dict]) -> None:
                 # chess.pgn stores a single comment string; join multiple entries
                 child_node.comment = " ".join(comments)
 
-            for nag_entry in entry.get("nags", []):
+            for nag_key_str in entry.get("nags", {}):
                 # JSON round-trip turns integer keys into strings ("2" not 2)
-                nag_key = int(list(nag_entry.keys())[0])
-                child_node.nags.add(nag_key)
+                child_node.nags.add(int(nag_key_str))
 
             current_node = child_node
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -65,7 +65,7 @@ def find_in_main_line(moves: list, san: str, turn: str | None = None) -> dict | 
 
 
 def nag_symbols(move: dict) -> list[str | None]:
-    return [list(n.values())[0] for n in move.get("nags", [])]
+    return list(move.get("nags", {}).values())
 
 
 # ---------------------------------------------------------------------------
@@ -199,12 +199,10 @@ class TestNags:
         nf6 = find_in_main_line(data["moves"], "Nf6", turn="black")
         assert nf6 is not None, "Nf6 (black, move 11) not found in main line"
         assert "nags" in nf6, "Expected $10 NAG on Nf6"
-        nag_keys = [list(n.keys())[0] for n in nf6["nags"]]
         # JSON serialises integer dict keys as strings, so 10 → "10"
-        assert "10" in nag_keys, f"Expected NAG key '10', got {nag_keys}"
+        assert "10" in nf6["nags"], f"Expected NAG key '10', got {list(nf6['nags'].keys())}"
         # NAG 10 = NAG_DRAWISH_POSITION → symbol "="
-        nag10_entry = next(n for n in nf6["nags"] if list(n.keys())[0] == "10")
-        assert list(nag10_entry.values())[0] == "="
+        assert nf6["nags"]["10"] == "="
 
     def test_clean_moves_have_no_nags(self):
         # d4 (first move) carries no annotation

--- a/tests/test_json_exporter.py
+++ b/tests/test_json_exporter.py
@@ -310,8 +310,7 @@ class TestNagMapping:
         e4 = data["moves"][0]
         assert "nags" in e4, f"Expected NAG on e4 for NAG {nag}"
         # JSON round-trip turns int keys to strings
-        entry = next(n for n in e4["nags"] if list(n.keys())[0] == str(nag))
-        return list(entry.values())[0]
+        return e4["nags"][str(nag)]
 
     def test_integration_forced_move(self):
         from chess.pgn import NAG_FORCED_MOVE


### PR DESCRIPTION
Closes #7

## Changes

Simplifies NAG encoding from a list of one-key dicts to a single code→symbol dict.

**Before:** `"nags": [{"14": "⩲"}, {"1": "!"}]`
**After:** `"nags": {"14": "⩲", "1": "!"}`
**EDN:** `:nags {14 "⩲" 1 "!"}`

- **`json_exporter.py`**: `visit_nag()` builds a single dict instead of appending one-key dicts
- **`json_parser.py`**: NAG parsing iterates over dict keys instead of a list of dicts
- **Tests**: Updated `test_json_exporter.py` and `test_functional.py` for new dict structure

All 204 tests pass.
