### PR TITLE
Add branch_fen to variation wrappers in JSON/EDN output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The tool produces a JSON (or EDN) object with three top-level keys:
 }
 ```
 
-Variations appear inline as `{ "variation": [ ... ] }` entries within the `moves` array.
+Variations appear inline as `{ "variation": [ ... ], "branch_fen": "<FEN>" }` entries within the `moves` array, where `branch_fen` is the board position from which the variation's moves are played.
 
 ---
 

--- a/chesstree/json_exporter.py
+++ b/chesstree/json_exporter.py
@@ -156,7 +156,17 @@ class JsonExporter(BaseVisitor[str]):
         if not self.variations_flag:
             return SKIP
         variation: List[dict] = []
-        self.current_variation.append({"variation": variation})
+        # Walk backwards to find the preceding move entry (skip variation
+        # wrappers that may sit between us and the actual move).
+        branch_fen: str | None = None
+        for entry in reversed(self.current_variation):
+            if "fen_before" in entry:
+                branch_fen = entry["fen_before"]
+                break
+        wrapper: dict = {"variation": variation}
+        if branch_fen is not None:
+            wrapper["branch_fen"] = branch_fen
+        self.current_variation.append(wrapper)
         self.variation_stack.append(self.current_variation)
         self.current_variation = variation
         return None

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -266,6 +266,23 @@ class TestVariations:
                 for c in move["comments"]:
                     assert isinstance(c, str), f"Each comment should be a string, got {type(c)}"
 
+    def test_branch_fen_equals_first_variation_move_fen_before(self):
+        """branch_fen on every variation wrapper must equal the first move's fen_before."""
+        data = convert(HILLBILLY)
+
+        def check_branch_fens(moves: list) -> None:
+            for entry in moves:
+                if "variation" in entry:
+                    assert "branch_fen" in entry, "variation wrapper missing branch_fen"
+                    first_move = entry["variation"][0]
+                    assert entry["branch_fen"] == first_move["fen_before"], (
+                        f"branch_fen {entry['branch_fen']!r} != "
+                        f"first move fen_before {first_move['fen_before']!r}"
+                    )
+                    check_branch_fens(entry["variation"])
+
+        check_branch_fens(data["moves"])
+
     def test_lisperer_has_variations_and_comments(self):
         # The annotated real game has both
         data = convert(LISPERER)

--- a/tests/test_json_exporter.py
+++ b/tests/test_json_exporter.py
@@ -111,6 +111,19 @@ class TestJsonExporter:
         variation_entries = [m for m in data["moves"] if "variation" in m]
         assert len(variation_entries) == 1
 
+    def test_variation_has_branch_fen(self):
+        game = _parse_game(VARIATION_PGN)
+        exporter = JsonExporter(variations=True)
+        data = json.loads(game.accept(exporter))
+        variation_entry = next(m for m in data["moves"] if "variation" in m)
+        assert "branch_fen" in variation_entry
+        # branch_fen must equal fen_before of the preceding move (1... e5),
+        # which is the position after 1. e4 — where black is to move
+        e5_move = data["moves"][1]
+        assert variation_entry["branch_fen"] == e5_move["fen_before"]
+        # It should also match the first variation move's fen_before
+        assert variation_entry["branch_fen"] == variation_entry["variation"][0]["fen_before"]
+
     def test_variations_excluded(self):
         game = _parse_game(VARIATION_PGN)
         exporter = JsonExporter(variations=False)


### PR DESCRIPTION
Closes #5

## Changes

Adds a `branch_fen` field to each variation wrapper in JSON/EDN output, making the branching point explicit without requiring positional context.

- **`json_exporter.py`**: `begin_variation()` walks backwards through `current_variation` to find the preceding move entry's `fen_before` and includes it as `branch_fen`
- **`test_json_exporter.py`**: Added `test_variation_has_branch_fen` — asserts presence and correctness
- **`test_functional.py`**: Added `test_branch_fen_equals_first_variation_move_fen_before` — recursively verifies the invariant across all variations in the deeply-nested Hillbilly PGN
- **`README.md`**: Updated variation description

All 206 tests pass.
