### PR TITLE
Remove board_img_after from JSON/EDN output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chesstree
 
-A command-line tool for converting chess games between PGN, JSON, EDN, GraphViz DOT, and interactive HTML formats. It accepts PGN or chesstree JSON as input (auto-detected from the file extension) and can output JSON, EDN, PGN, DOT, or dothtml via the `-f`/`--format` flag. JSON output includes move number, SAN and UCI notation, FEN position, SVG board images, comments, NAGs, and variations. DOT output models the game tree as a left-to-right digraph suitable for rendering with GraphViz tools. The dothtml format wraps the DOT graph in a self-contained browser viewer powered by [d3-graphviz](https://github.com/magjac/d3-graphviz), with pan, zoom, and board images included.
+A command-line tool for converting chess games between PGN, JSON, EDN, GraphViz DOT, and interactive HTML formats. It accepts PGN or chesstree JSON as input (auto-detected from the file extension) and can output JSON, EDN, PGN, DOT, or dothtml via the `-f`/`--format` flag. JSON output includes move number, SAN and UCI notation, FEN positions, comments, NAGs, and variations. DOT output models the game tree as a left-to-right digraph suitable for rendering with GraphViz tools. The dothtml format wraps the DOT graph in a self-contained browser viewer powered by [d3-graphviz](https://github.com/magjac/d3-graphviz), with pan, zoom, and board images included.
 
 ## Output format
 
@@ -16,8 +16,7 @@ The tool produces a JSON (or EDN) object with three top-level keys:
       "san": "e4",
       "uci": "e2e4",
       "fen_before": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
-      "fen_after": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1",
-      "board_img_after":  "<svg ...>"
+      "fen_after": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
     },
     ...
   ],
@@ -80,12 +79,13 @@ options:
   -o, --output OUTPUT                     Output file (default: stdout)
   -f, --format {json,edn,pgn,dot,dothtml} Output format: json (default), edn, pgn, dot, or dothtml
   --input-format {pgn,json}               Override auto-detected input format
-  -b, --forblack                          Board images from Black's perspective (json/edn/dot/dothtml)
-  --images MODE [MODE ...]                Image generation mode (default: variations)
+  -b, --forblack                          Board images from Black's perspective (dot/dothtml)
+  --images MODE [MODE ...]                Image generation mode for dot/dothtml output (default: variations)
                                           Choices: none, all, variations, commented.
                                           'variations' and 'commented' may be combined.
-                                          For dot/dothtml output, SVG files are written alongside
-                                          the output file; stdout skips writing SVGs.
+                                          SVG files are written alongside the output file;
+                                          stdout skips writing SVGs.
+                                          Has no effect on json/edn output.
   --template FILE                         Custom HTML template for dothtml output.
                                           Must contain {{CHESSTREE_TITLE}}, {{CHESSTREE_IMAGES}},
                                           and {{CHESSTREE_DOT}} placeholders. Only used with -f dothtml.
@@ -126,15 +126,15 @@ Print compact JSON to stdout:
 cat game.pgn | chesstree -i - -c
 ```
 
-Generate board images from Black's perspective:
+Generate board images from Black's perspective (dot/dothtml output):
 
 ```bash
-chesstree -i game.pgn -o game.json -b
+chesstree -i game.pgn -f dot -o game.dot -b
 ```
 
 ### Board image modes
 
-The `--images` flag controls which moves carry a board image in JSON/EDN output and which segment nodes carry an SVG image row in DOT/dothtml output. The following modes are available:
+The `--images` flag controls which segment nodes carry an SVG image row in DOT/dothtml output. It has no effect on JSON/EDN output (which never contains embedded images — use the `fen_after` field to generate board visuals with any chess library). The following modes are available:
 
 | Mode | Description |
 |------|-------------|
@@ -154,34 +154,34 @@ A chess game tree is naturally divided into **segments** — runs of moves along
 
 This means images appear at the moments of decision — exactly where a reader is most likely to want to visualise the board — while keeping the output compact compared to `all`.
 
-Generate images only at variation endpoints (default):
+Generate images only at variation endpoints (default, dot/dothtml only):
 
 ```bash
-chesstree -i game.pgn -o game.json --images variations
+chesstree -i game.pgn -f dot -o game.dot --images variations
 ```
 
 Generate images for every move:
 
 ```bash
-chesstree -i game.pgn -o game.json --images all
+chesstree -i game.pgn -f dot -o game.dot --images all
 ```
 
 Generate images only at commented moves:
 
 ```bash
-chesstree -i game.pgn -o game.json --images commented
+chesstree -i game.pgn -f dot -o game.dot --images commented
 ```
 
 Generate images at both variation endpoints and commented moves:
 
 ```bash
-chesstree -i game.pgn -o game.json --images variations commented
+chesstree -i game.pgn -f dot -o game.dot --images variations commented
 ```
 
 Omit all board images:
 
 ```bash
-chesstree -i game.pgn -o game.json --images none
+chesstree -i game.pgn -f dot -o game.dot --images none
 ```
 
 Convert a chesstree JSON file back to PGN:

--- a/chesstree/cli.py
+++ b/chesstree/cli.py
@@ -17,7 +17,6 @@ except ImportError:
     __version__ = "unknown"
 
 from chesstree import json_exporter
-from chesstree.json_exporter import collect_image_fens
 from chesstree.json_parser import parse_json
 from chesstree.dot_exporter import export_dot
 from chesstree.dothtml_exporter import export_dothtml
@@ -55,7 +54,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "-b", "--forblack",
         action="store_true",
-        help="Board images from Black's perspective (json/edn/dot output)",
+        help="Board images from Black's perspective (dot/dothtml output)",
     )
     parser.add_argument(
         "--images",
@@ -64,11 +63,12 @@ def parse_args() -> argparse.Namespace:
         default=["variations"],
         metavar="MODE",
         help=(
-            "Image generation mode (default: variations). "
+            "Image generation mode for dot/dothtml output (default: variations). "
             "Choices: none, all, variations, commented. "
             "'variations' and 'commented' may be combined. "
-            "For dot/dothtml output, SVG files are written alongside the output file; "
-            "stdout output includes image references but does not write SVG files."
+            "SVG files are written alongside the output file; "
+            "stdout output includes image references but does not write SVG files. "
+            "Has no effect on json/edn output."
         ),
     )
     parser.add_argument(
@@ -102,10 +102,8 @@ def _detect_input_format(input_file: TextIO, override: str | None) -> str:
 def pgn_to_json(
     input_pgn: TextIO,
     output_json: TextIO,
-    forblack: bool,
     edn: bool,
     concise: bool = False,
-    images: list | None = None,
 ) -> None:
     extension = "edn" if edn else "json"
     print(f"Reading {input_pgn.name} and converting to {extension}", file=sys.stderr)
@@ -115,17 +113,12 @@ def pgn_to_json(
         print(f"Error: no valid PGN game found in {input_pgn.name}", file=sys.stderr)
         sys.exit(1)
 
-    modes = frozenset(images or ["variations"])
-    image_fens = collect_image_fens(parsed_game, modes)
-
     exporter = json_exporter.JsonExporter(
         headers=True,
         variations=True,
         comments=True,
         edn=edn,
-        board_img_for_black=forblack,
         concise=concise,
-        image_fens=image_fens,
     )
     game_json_edn = parsed_game.accept(exporter)
     print(game_json_edn, file=output_json, end="\n\n")
@@ -248,10 +241,8 @@ def cli() -> None:
 
     if input_fmt == "pgn" and output_fmt in ("json", "edn"):
         pgn_to_json(args.input, args.output,
-                    forblack=args.forblack,
                     edn=(output_fmt == "edn"),
-                    concise=args.concise,
-                    images=args.images)
+                    concise=args.concise)
     elif input_fmt == "json" and output_fmt == "pgn":
         json_to_pgn(args.input, args.output)
     elif input_fmt in ("pgn", "json") and output_fmt == "dot":

--- a/chesstree/json_exporter.py
+++ b/chesstree/json_exporter.py
@@ -117,17 +117,12 @@ class JsonExporter(BaseVisitor[str]):
         variations: bool = True,
         edn: bool = False,
         concise: bool = False,
-        board_img_for_black: bool = False,
-        image_fens: Optional[set] = None,
     ):
         self.headers_flag = headers
         self.comments_flag = comments
         self.variations_flag = variations
         self.edn_flag = edn
-        self.board_img_for_black_flag = board_img_for_black
         self.indent = None if concise else 2
-        # None → all moves get images; set → only matching FENs (empty set = no images)
-        self.image_fens = image_fens
 
         self.reset_game()
 
@@ -196,7 +191,6 @@ class JsonExporter(BaseVisitor[str]):
         board_after = board.copy()
         board_after.push(move)
         fen_after = board_after.fen()
-        orientation = chess.BLACK if self.board_img_for_black_flag else chess.WHITE
         move_entry = {
             "move_number": board.fullmove_number,
             "turn": "white" if board.turn == chess.WHITE else "black",
@@ -205,10 +199,6 @@ class JsonExporter(BaseVisitor[str]):
             "fen_before": board.fen(),
             "fen_after": fen_after,
         }
-        if self.image_fens is None or fen_after in self.image_fens:
-            move_entry["board_img_after"] = chess.svg.board(
-                board_after, size=250, orientation=orientation
-            ).replace('"', '\\"')
         self.current_variation.append(move_entry)
 
     def visit_result(self, result: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def _pgn_to_json_str(pgn: str) -> str:
 class TestPgnToJson:
     def test_basic_conversion_produces_valid_json(self):
         output_f = _make_output()
-        pgn_to_json(_make_input(SIMPLE_PGN), output_f, forblack=False, edn=False)
+        pgn_to_json(_make_input(SIMPLE_PGN), output_f, edn=False)
         output_f.seek(0)
         data = json.loads(output_f.read())
         assert data["headers"]["White"] == "Alice"
@@ -51,7 +51,7 @@ class TestPgnToJson:
 
     def test_edn_output(self):
         output_f = _make_output()
-        pgn_to_json(_make_input(SIMPLE_PGN), output_f, forblack=False, edn=True)
+        pgn_to_json(_make_input(SIMPLE_PGN), output_f, edn=True)
         output_f.seek(0)
         result = output_f.read()
         assert ":headers" in result
@@ -59,16 +59,17 @@ class TestPgnToJson:
 
     def test_concise_output(self):
         output_f = _make_output()
-        pgn_to_json(_make_input(SIMPLE_PGN), output_f, forblack=False, edn=False, concise=True)
+        pgn_to_json(_make_input(SIMPLE_PGN), output_f, edn=False, concise=True)
         output_f.seek(0)
         # Trim trailing newlines added by print(..., end="\n\n")
         result = output_f.read().strip()
         assert "\n" not in result
 
     def test_forblack_flag_accepted(self):
-        """Smoke test that the forblack flag doesn't raise."""
+        """Smoke test: pgn_to_json no longer accepts forblack; this test
+        verifies the basic conversion still works."""
         output_f = _make_output()
-        pgn_to_json(_make_input(SIMPLE_PGN), output_f, forblack=True, edn=False)
+        pgn_to_json(_make_input(SIMPLE_PGN), output_f, edn=False)
         output_f.seek(0)
         data = json.loads(output_f.read())
         assert len(data["moves"]) > 0
@@ -76,7 +77,7 @@ class TestPgnToJson:
     def test_empty_pgn_exits_with_error(self):
         output_f = _make_output()
         with pytest.raises(SystemExit) as exc_info:
-            pgn_to_json(_make_input(EMPTY_PGN), output_f, forblack=False, edn=False)
+            pgn_to_json(_make_input(EMPTY_PGN), output_f, edn=False)
         assert exc_info.value.code == 1
 
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -32,12 +32,12 @@ GERGESHAIN = SAMPLE_PGNS / "gergeshain-vs-lisperer.pgn"
 # Helpers
 # ---------------------------------------------------------------------------
 
-def convert(pgn_path: pathlib.Path, forblack: bool = False, edn: bool = False, concise: bool = False, images: list | None = None) -> dict:
+def convert(pgn_path: pathlib.Path, edn: bool = False, concise: bool = False) -> dict:
     """Run the full pgn_to_json pipeline and return the parsed JSON dict."""
     output = io.StringIO()
     output.name = "<stdout>"
     with open(pgn_path) as f:
-        pgn_to_json(f, output, forblack=forblack, edn=edn, concise=concise, images=images)
+        pgn_to_json(f, output, edn=edn, concise=concise)
     output.seek(0)
     return json.loads(output.read())
 
@@ -72,73 +72,25 @@ def nag_symbols(move: dict) -> list[str | None]:
 # Board images
 # ---------------------------------------------------------------------------
 
-class TestBoardImages:
-    def test_all_mode_every_move_has_image(self):
-        data = convert(LISPERER, images=["all"])
-        moves = main_line_moves(data["moves"])
-        assert len(moves) > 0
-        for move in moves:
-            assert "board_img_after" in move, f"Missing board_img_after on {move['san']}"
+# ---------------------------------------------------------------------------
+# Board images are no longer in JSON output
+# ---------------------------------------------------------------------------
 
-    def test_all_mode_variation_moves_have_images(self):
-        data = convert(HILLBILLY, images=["all"])
-        all_moves = list(iter_moves(data["moves"]))
-        assert all_moves, "No moves found"
-        for move in all_moves:
-            assert "board_img_after" in move, f"Missing board_img_after in variation on {move['san']}"
-
-    def test_board_images_contain_svg(self):
-        data = convert(LISPERER, images=["all"])
-        for move in main_line_moves(data["moves"]):
-            assert move["board_img_after"].startswith("<svg"), f"board_img_after not SVG on {move['san']}"
-
-    def test_none_mode_no_images(self):
-        data = convert(LISPERER, images=["none"])
+class TestNoBoardImagesInJson:
+    def test_no_board_img_after_in_any_move(self):
+        data = convert(LISPERER)
         for move in iter_moves(data["moves"]):
             assert "board_img_after" not in move, f"Unexpected board_img_after on {move['san']}"
 
-    def test_variations_mode_is_default(self):
-        data_default = convert(LISPERER)
-        data_explicit = convert(LISPERER, images=["variations"])
-        # Same number of moves with images
-        default_with_img = sum(1 for m in iter_moves(data_default["moves"]) if "board_img_after" in m)
-        explicit_with_img = sum(1 for m in iter_moves(data_explicit["moves"]) if "board_img_after" in m)
-        assert default_with_img == explicit_with_img
-
-    def test_variations_mode_fewer_images_than_all(self):
-        data_all = convert(LISPERER, images=["all"])
-        data_vars = convert(LISPERER, images=["variations"])
-        all_count = sum(1 for m in iter_moves(data_all["moves"]) if "board_img_after" in m)
-        vars_count = sum(1 for m in iter_moves(data_vars["moves"]) if "board_img_after" in m)
-        assert vars_count < all_count
-
-    def test_variations_mode_last_move_has_image(self):
-        data = convert(LISPERER, images=["variations"])
-        main = main_line_moves(data["moves"])
-        assert "board_img_after" in main[-1], "Last main-line move should have an image in variations mode"
-
-    def test_commented_mode_only_commented_moves_have_images(self):
-        data = convert(LISPERER, images=["commented"])
+    def test_no_board_img_after_in_variation_moves(self):
+        data = convert(HILLBILLY)
         for move in iter_moves(data["moves"]):
-            has_img = "board_img_after" in move
-            has_comment = bool(move.get("comments"))
-            assert has_img == has_comment, (
-                f"Move {move['san']}: image={has_img} but comment={has_comment}"
-            )
+            assert "board_img_after" not in move, f"Unexpected board_img_after on {move['san']}"
 
-    def test_variations_and_commented_combined(self):
-        data_vars = convert(LISPERER, images=["variations"])
-        data_both = convert(LISPERER, images=["variations", "commented"])
-        vars_count = sum(1 for m in iter_moves(data_vars["moves"]) if "board_img_after" in m)
-        both_count = sum(1 for m in iter_moves(data_both["moves"]) if "board_img_after" in m)
-        assert both_count >= vars_count
-
-    def test_black_orientation_produces_different_svg(self):
-        data_white = convert(LISPERER, forblack=False, images=["all"])
-        data_black = convert(LISPERER, forblack=True, images=["all"])
-        first_white = data_white["moves"][0]["board_img_after"]
-        first_black = data_black["moves"][0]["board_img_after"]
-        assert first_white != first_black, "Board SVG should differ between white and black orientation"
+    def test_fen_after_still_present(self):
+        data = convert(LISPERER)
+        for move in iter_moves(data["moves"]):
+            assert "fen_after" in move, f"Missing fen_after on {move['san']}"
 
 
 # ---------------------------------------------------------------------------
@@ -348,28 +300,24 @@ class TestGergeshainLisperer:
                 assert "[%clk" not in c, f"[%clk] leaked into comments of move {move['san']}: {c!r}"
 
     def test_commented_mode_no_image_on_clock_only_moves(self):
-        """Moves annotated only with [%clk] must NOT trigger a board image in 'commented' mode."""
-        data = convert(GERGESHAIN, images=["commented"])
-        # e4 is the very first move; its only annotation is [%clk 0:05:00]
-        e4 = find_in_main_line(data["moves"], "e4", turn="white")
-        assert e4 is not None, "e4 not found in main line"
-        assert "board_img_after" not in e4, "e4 (clock-only annotation) should not have a board image"
+        """In commented mode, DOT output should not produce images for clock-only moves."""
+        game = _load_game(GERGESHAIN)
+        _, images_commented = export_dot(game, image_modes=frozenset(["commented"]))
+        _, images_all = export_dot(game, image_modes=frozenset(["all"]))
+        assert len(images_commented) < len(images_all)
 
     def test_commented_mode_image_on_real_comment_moves(self):
-        """Moves with genuine human commentary DO get a board image in 'commented' mode."""
-        data = convert(GERGESHAIN, images=["commented"])
-        # 20... Rhg8 has the comment "was trying to find counterplay desperately"
-        rhg8 = find_in_main_line(data["moves"], "Rhg8", turn="black")
-        assert rhg8 is not None, "Rhg8 not found in main line"
-        assert "board_img_after" in rhg8, "Rhg8 (has real comment) should have a board image"
+        """In commented mode, DOT output should produce images for real-comment moves."""
+        game = _load_game(GERGESHAIN)
+        _, images_commented = export_dot(game, image_modes=frozenset(["commented"]))
+        assert len(images_commented) > 0
 
     def test_fewer_commented_images_than_all(self):
-        data_all = convert(GERGESHAIN, images=["all"])
-        data_commented = convert(GERGESHAIN, images=["commented"])
-        all_count = sum(1 for m in iter_moves(data_all["moves"]) if "board_img_after" in m)
-        commented_count = sum(1 for m in iter_moves(data_commented["moves"]) if "board_img_after" in m)
-        assert commented_count < all_count, (
-            f"commented mode ({commented_count}) should produce fewer images than all mode ({all_count})"
+        game = _load_game(GERGESHAIN)
+        _, images_all = export_dot(game, image_modes=frozenset(["all"]))
+        _, images_commented = export_dot(game, image_modes=frozenset(["commented"]))
+        assert len(images_commented) < len(images_all), (
+            f"commented mode ({len(images_commented)}) should produce fewer DOT SVGs than all mode ({len(images_all)})"
         )
 
     def test_real_comments_present_on_annotated_moves(self):

--- a/tests/test_json_exporter.py
+++ b/tests/test_json_exporter.py
@@ -75,7 +75,7 @@ class TestJsonExporter:
         assert "fen_before" in first_move
         assert "fen_after" in first_move
         assert "uci" in first_move
-        assert "board_img_after" in first_move
+        assert "board_img_after" not in first_move
 
     def test_result(self):
         game = _parse_game(SIMPLE_PGN)


### PR DESCRIPTION
Closes #6

## Changes

Removes `board_img_after` from JSON/EDN output entirely. JSON/EDN is now a pure data format.

- **`json_exporter.py`**: Removed `image_fens`, `board_img_for_black` params and SVG generation from `JsonExporter`
- **`cli.py`**: Simplified `pgn_to_json()` — removed image-related params. Updated `--images` and `-b` help text to reflect DOT/dothtml-only scope
- **Tests**: Updated across `test_json_exporter.py`, `test_cli.py`, `test_functional.py` — image tests now use DOT exporter directly
- **`README.md`**: Removed `board_img_after` from JSON example, updated docs

`collect_image_fens()` is preserved — still used by the DOT/dothtml pipeline.

All 197 tests pass.
