### PR TITLE
Add schema_version field to JSON/EDN output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ A command-line tool for converting chess games between PGN, JSON, EDN, GraphViz 
 
 ## Output format
 
-The tool produces a JSON (or EDN) object with three top-level keys:
+The tool produces a JSON (or EDN) object with four top-level keys:
 
 ```json
 {
+  "schema_version": "0.1.0",
   "headers": { "White": "Alice", "Black": "Bob", "Result": "1-0", ... },
   "moves": [
     {

--- a/chesstree/json_exporter.py
+++ b/chesstree/json_exporter.py
@@ -185,6 +185,7 @@ class JsonExporter(BaseVisitor[str]):
 
     def reset_game(self) -> None:
         self.game_data: dict = {
+            "schema_version": "0.1.0",
             "headers": {},
             "moves": [],
             "result": None,

--- a/chesstree/json_parser.py
+++ b/chesstree/json_parser.py
@@ -82,6 +82,8 @@ def parse_json(json_data: dict) -> chess.pgn.Game:
     Parse a JSON dict (as produced by JsonExporter) into a chess.pgn.Game.
 
     Board images (board_img_before / board_img_after) are ignored.
+    The ``schema_version`` field is tolerated whether present or absent
+    (pre-versioned files simply omit it).
     EDN input is not supported; pass a Python dict parsed from JSON.
     """
     game = chess.pgn.Game()

--- a/tests/test_json_exporter.py
+++ b/tests/test_json_exporter.py
@@ -45,6 +45,24 @@ class TestJsonExporter:
         data = json.loads(result)
         assert isinstance(data, dict)
 
+    def test_schema_version_present(self):
+        game = _parse_game(SIMPLE_PGN)
+        exporter = JsonExporter()
+        data = json.loads(game.accept(exporter))
+        assert data["schema_version"] == "0.1.0"
+
+    def test_schema_version_is_first_key(self):
+        game = _parse_game(SIMPLE_PGN)
+        exporter = JsonExporter()
+        data = json.loads(game.accept(exporter))
+        assert list(data.keys())[0] == "schema_version"
+
+    def test_schema_version_in_edn(self):
+        game = _parse_game(SIMPLE_PGN)
+        exporter = JsonExporter(edn=True)
+        result = game.accept(exporter)
+        assert result.startswith('{:schema-version "0.1.0"')
+
     def test_headers_included(self):
         game = _parse_game(SIMPLE_PGN)
         exporter = JsonExporter(headers=True)
@@ -100,6 +118,7 @@ class TestJsonExporter:
         exporter = JsonExporter(edn=True)
         result = game.accept(exporter)
         assert result.startswith("{")
+        assert ":schema-version" in result
         assert ":headers" in result
         assert ":moves" in result
 


### PR DESCRIPTION
## Summary

Add a top-level `schema_version` field to JSON/EDN output so every document is self-describing.

## Changes

- **`json_exporter.py`**: `schema_version: "0.1.0"` is now the first key in the output dict, appearing first in both JSON and EDN output.
- **`json_parser.py`**: Updated docstring — the parser already tolerates absent `schema_version` (pre-versioned files) by ignoring unknown keys.
- **`tests/test_json_exporter.py`**: Added tests for `schema_version` presence, first-key ordering, and EDN rendering.
- **`README.md`**: Updated JSON example to include `schema_version`.

Closes #14