### PR TITLE
Add d3html interactive tree output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chesstree
 
-A command-line tool for converting chess games between PGN, JSON, EDN, GraphViz DOT, and interactive HTML formats. It accepts PGN or chesstree JSON as input (auto-detected from the file extension) and can output JSON, EDN, PGN, DOT, or dothtml via the `-f`/`--format` flag. JSON output includes move number, SAN and UCI notation, FEN positions, comments, NAGs, and variations. DOT output models the game tree as a left-to-right digraph suitable for rendering with GraphViz tools. The dothtml format wraps the DOT graph in a self-contained browser viewer powered by [d3-graphviz](https://github.com/magjac/d3-graphviz), with pan, zoom, and board images included.
+A command-line tool for converting chess games between PGN, JSON, EDN, GraphViz DOT, and interactive HTML formats. It accepts PGN or chesstree JSON as input (auto-detected from the file extension) and can output JSON, EDN, PGN, DOT, dothtml, or d3html via the `-f`/`--format` flag. JSON output includes move number, SAN and UCI notation, FEN positions, comments, NAGs, and variations. DOT output models the game tree as a left-to-right digraph suitable for rendering with GraphViz tools. The `dothtml` format wraps the DOT graph in a self-contained browser viewer powered by [d3-graphviz](https://github.com/magjac/d3-graphviz), with pan, zoom, and board images included. The `d3html` format produces a purpose-built interactive D3.js tree viewer with collapsible nodes, variation highlighting, optional hover board images, and a dark-themed layout — no GraphViz dependency required.
 
 ## Output format
 
@@ -69,28 +69,33 @@ The `chesstree` command is available whenever the virtual environment is active.
 ## Usage
 
 ```
-usage: chesstree [-h] [--version] -i INPUT [-o OUTPUT] [-f {json,edn,pgn,dot,dothtml}]
+usage: chesstree [-h] [--version] -i INPUT [-o OUTPUT] [-f {json,edn,pgn,dot,dothtml,d3html}]
                  [--input-format {pgn,json}] [-b] [--images MODE [MODE ...]]
-                 [--template FILE] [-c]
+                 [--template FILE] [-a] [--no-move-highlight] [-c]
 
 options:
-  -h, --help                              show this help message and exit
-  --version                               show program's version number and exit
-  -i, --input INPUT                       Input file — PGN or chesstree JSON (use '-' for stdin)
-  -o, --output OUTPUT                     Output file (default: stdout)
-  -f, --format {json,edn,pgn,dot,dothtml} Output format: json (default), edn, pgn, dot, or dothtml
-  --input-format {pgn,json}               Override auto-detected input format
-  -b, --forblack                          Board images from Black's perspective (dot/dothtml)
-  --images MODE [MODE ...]                Image generation mode for dot/dothtml output (default: variations)
-                                          Choices: none, all, variations, commented.
-                                          'variations' and 'commented' may be combined.
-                                          SVG files are written alongside the output file;
-                                          stdout skips writing SVGs.
-                                          Has no effect on json/edn output.
-  --template FILE                         Custom HTML template for dothtml output.
-                                          Must contain {{CHESSTREE_TITLE}}, {{CHESSTREE_IMAGES}},
-                                          and {{CHESSTREE_DOT}} placeholders. Only used with -f dothtml.
-  -c, --concise                           Compact output, no pretty-printing (json/edn output only)
+  -h, --help                                     show this help message and exit
+  --version                                      show program's version number and exit
+  -i, --input INPUT                              Input file — PGN or chesstree JSON (use '-' for stdin)
+  -o, --output OUTPUT                            Output file (default: stdout)
+  -f, --format {json,edn,pgn,dot,dothtml,d3html} Output format: json (default), edn, pgn, dot, dothtml, or d3html
+  --input-format {pgn,json}                      Override auto-detected input format
+  -b, --forblack                                 Board images from Black's perspective (dot/dothtml/d3html)
+  --images MODE [MODE ...]                       Image generation mode for dot/dothtml/d3html output (default: variations)
+                                                 Choices: none, all, variations, commented.
+                                                 'variations' and 'commented' may be combined.
+                                                 SVG files are written alongside the output file;
+                                                 stdout skips writing SVGs.
+                                                 Has no effect on json/edn output.
+  --template FILE                                Custom HTML template for dothtml or d3html output.
+                                                 Must contain the required placeholders for the chosen format.
+                                                 Only used with -f dothtml or -f d3html.
+  -a, --hover-for-all-moves                      Embed per-move hover board images (d3html only).
+                                                 Mouseover a move to see the board position in a popup.
+  --no-move-highlight                            Disable last-move square highlighting on board images.
+                                                 By default the from/to squares of the last move are
+                                                 coloured on every board image (dot/dothtml/d3html).
+  -c, --concise                                  Compact output, no pretty-printing (json/edn output only)
 ```
 
 The input format is auto-detected from the file extension (`.pgn` → PGN, `.json` → chesstree JSON). Use `--input-format` to override this when reading from stdin or a file with an unusual extension.
@@ -103,9 +108,11 @@ Supported conversions:
 | PGN   | `edn`             | chesstree EDN  |
 | PGN   | `dot`             | GraphViz DOT   |
 | PGN   | `dothtml`         | Self-contained d3-graphviz HTML viewer |
+| PGN   | `d3html`          | Self-contained D3.js interactive tree viewer |
 | JSON  | `pgn`             | PGN            |
 | JSON  | `dot`             | GraphViz DOT   |
 | JSON  | `dothtml`         | Self-contained d3-graphviz HTML viewer |
+| JSON  | `d3html`          | Self-contained D3.js interactive tree viewer |
 
 ### Examples
 
@@ -185,6 +192,18 @@ Omit all board images:
 chesstree -i game.pgn -f dot -o game.dot --images none
 ```
 
+### Last-move square highlighting
+
+By default, board images colour the **from** and **to** squares of the last move, making it easy to see which piece moved. This applies to all image-bearing formats: `dot`, `dothtml`, and `d3html`.
+
+Use `--no-move-highlight` to produce plain boards without any square colouring:
+
+```bash
+chesstree -i game.pgn -f dothtml -o game.html --no-move-highlight
+chesstree -i game.pgn -f d3html  -o game.html --no-move-highlight
+chesstree -i game.pgn -f dot     -o game.dot  --no-move-highlight
+```
+
 Convert a chesstree JSON file back to PGN:
 
 ```bash
@@ -209,7 +228,7 @@ Export from chesstree JSON to DOT:
 chesstree -i game.json -f dot -o game.dot
 ```
 
-### dothtml output — interactive browser viewer
+### dothtml output — d3-graphviz browser viewer
 
 The `dothtml` format produces a self-contained HTML file that renders the game tree interactively in a browser using [d3-graphviz](https://github.com/magjac/d3-graphviz). Board images are written as SVG files alongside the HTML file, which the browser loads by relative path.
 
@@ -229,7 +248,7 @@ When writing to **stdout**, image references are included in the HTML but no SVG
 chesstree -i game.pgn -f dothtml -o -
 ```
 
-#### Custom HTML template
+#### Custom HTML template (dothtml)
 
 You can supply your own template with `--template`:
 
@@ -241,11 +260,79 @@ The template is plain HTML with three required placeholders:
 
 | Placeholder | Replaced with |
 |-------------|---------------|
-| `{{CHESSTREE_TITLE}}` | Game title string (e.g. "White vs Black at 2024.01.01") — use in `<title>` and any heading |
-| `{{CHESSTREE_IMAGES}}` | One `.addImage("./name.svg", "144px", "144px")` call per image, one per line |
-| `{{CHESSTREE_DOT}}` | The raw DOT string — place this inside the JS backtick template literal assigned to `dot` |
+| `{{CHESSTREE_TITLE}}` | Game title string (e.g. "White vs Black at 2024.01.01") |
+| `{{CHESSTREE_IMAGES}}` | One `.addImage("./name.svg", "144px", "144px")` call per image |
+| `{{CHESSTREE_DOT}}` | The raw DOT string — place inside a JS backtick template literal |
 
-All three placeholders must be present in the template or generation will fail with an error listing which are missing. The built-in template at `chesstree/templates/default.html` in the project source is a good starting point for customisation.
+All three must be present or generation fails with an error listing the missing ones.
+
+---
+
+### d3html output — interactive D3.js tree viewer
+
+The `d3html` format produces a self-contained HTML file with a purpose-built interactive tree viewer powered by [D3.js v7](https://d3js.org). Unlike `dothtml` it does not require GraphViz: the layout and rendering are done entirely in the browser.
+
+```bash
+# Generate HTML viewer + SVG board images in ./output/
+chesstree -i game.pgn -f d3html -o output/game.html
+
+# Open in browser
+open output/game.html
+```
+
+Features of the viewer:
+
+- **Dark theme** with colour-coded nodes: main-line segments (blue) are visually distinct from variation segments (purple).
+- **Node headers** show the line type and move range, e.g. "Main line: 1–12" or "Variation: 8–10".
+- **Collapsible nodes** — click any node to hide its variation children while keeping the main-line continuation visible. A badge in the header shows how many nodes are hidden. Ctrl+click collapses all children including the main-line continuation.
+- **Pan and zoom** via scroll and drag.
+- **Drag-to-reposition** individual nodes.
+- **Hover board images** (optional, see `-a` below).
+- **R key / ↺ Reset button** restores the automatic layout.
+
+#### Board images in d3html
+
+The `--images` flag works the same as for `dot`/`dothtml`:
+
+```bash
+# Default: one image per segment endpoint
+chesstree -i game.pgn -f d3html -o game.html
+
+# Images at both variation endpoints and commented moves
+chesstree -i game.pgn -f d3html -o game.html --images variations commented
+
+# No images (smallest output)
+chesstree -i game.pgn -f d3html -o game.html --images none
+```
+
+SVG files are written alongside the HTML file. When writing to stdout, image references are included but no SVG files are written.
+
+#### Hover board images (`-a`)
+
+The `-a` / `--hover-for-all-moves` flag embeds a miniature board image for every individual move. Hovering over any move token in the tree shows the board position at that move in a popup:
+
+```bash
+chesstree -i game.pgn -f d3html -o game.html -a
+```
+
+This significantly increases file size (one small SVG per move) so it is off by default.
+
+#### Custom HTML template (d3html)
+
+```bash
+chesstree -i game.pgn -f d3html --template my_d3_template.html -o game.html
+```
+
+The d3html template has four required placeholders (different from the dothtml placeholders):
+
+| Placeholder | Replaced with |
+|-------------|---------------|
+| `{{CHESSTREE_TITLE}}` | Game title string |
+| `{{CHESSTREE_TREE_DATA}}` | JSON tree data object (embed inside `JSON.parse(\`...\`)`) |
+| `{{CHESSTREE_IMAGES}}` | JS statements that populate the `boardImages` dict, one per SVG file |
+| `{{CHESSTREE_HOVER_DATA}}` | JS statements that populate the `hoverImages` dict (empty when `-a` not used) |
+
+All four must be present or generation fails.
 
 ### DOT output and board images
 

--- a/chesstree/cli.py
+++ b/chesstree/cli.py
@@ -20,6 +20,7 @@ from chesstree import json_exporter
 from chesstree.json_parser import parse_json
 from chesstree.dot_exporter import export_dot
 from chesstree.dothtml_exporter import export_dothtml
+from chesstree.d3html_exporter import export_d3html
 
 
 def parse_args() -> argparse.Namespace:
@@ -41,9 +42,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "-f", "--format",
-        choices=["json", "edn", "pgn", "dot", "dothtml"],
+        choices=["json", "edn", "pgn", "dot", "dothtml", "d3html"],
         default="json",
-        help="Output format: json (default), edn, pgn, dot, or dothtml",
+        help="Output format: json (default), edn, pgn, dot, dothtml, or d3html",
     )
     parser.add_argument(
         "--input-format",
@@ -63,7 +64,7 @@ def parse_args() -> argparse.Namespace:
         default=["variations"],
         metavar="MODE",
         help=(
-            "Image generation mode for dot/dothtml output (default: variations). "
+            "Image generation mode for dot/dothtml/d3html output (default: variations). "
             "Choices: none, all, variations, commented. "
             "'variations' and 'commented' may be combined. "
             "SVG files are written alongside the output file; "
@@ -77,9 +78,27 @@ def parse_args() -> argparse.Namespace:
         default=None,
         metavar="FILE",
         help=(
-            "Custom HTML template file for dothtml output. "
-            "Must contain the placeholders {{CHESSTREE_TITLE}}, {{CHESSTREE_IMAGES}}, "
-            "and {{CHESSTREE_DOT}}. Only used with -f dothtml."
+            "Custom HTML template file for dothtml or d3html output. "
+            "Must contain the required placeholders for the chosen format. "
+            "Only used with -f dothtml or -f d3html."
+        ),
+    )
+    parser.add_argument(
+        "-a", "--hover-for-all-moves",
+        action="store_true",
+        dest="hover",
+        help=(
+            "Embed per-move hover board images (d3html output only). "
+            "Mouseover a move to see the board position in a popup."
+        ),
+    )
+    parser.add_argument(
+        "--no-move-highlight",
+        action="store_false",
+        dest="highlight_last_move",
+        help=(
+            "Disable last-move square highlighting on board images "
+            "(dot/dothtml/d3html output only). Highlighting is on by default."
         ),
     )
     parser.add_argument(
@@ -145,6 +164,7 @@ def game_to_dot(
     input_fmt: str,
     images: list | None = None,
     forblack: bool = False,
+    highlight_last_move: bool = True,
 ) -> None:
     print(f"Reading {input_file.name} and converting to DOT", file=sys.stderr)
 
@@ -162,7 +182,7 @@ def game_to_dot(
             sys.exit(1)
 
     modes = frozenset(images or ["variations"])
-    dot_str, images_dict = export_dot(game, image_modes=modes, board_img_for_black=forblack)
+    dot_str, images_dict = export_dot(game, image_modes=modes, board_img_for_black=forblack, highlight_last_move=highlight_last_move)
     print(dot_str, file=output_file)
 
     is_stdout = getattr(output_file, "name", "<stdout>") == "<stdout>"
@@ -185,6 +205,7 @@ def game_to_dothtml(
     images: list | None = None,
     forblack: bool = False,
     template_file: TextIO | None = None,
+    highlight_last_move: bool = True,
 ) -> None:
     print(f"Reading {input_file.name} and converting to dothtml", file=sys.stderr)
 
@@ -210,6 +231,7 @@ def game_to_dothtml(
             image_modes=modes,
             board_img_for_black=forblack,
             template_path=template_path,
+            highlight_last_move=highlight_last_move,
         )
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
@@ -230,11 +252,70 @@ def game_to_dothtml(
     print(f"Conversion to dothtml done, written to {output_file.name}", file=sys.stderr)
 
 
+def game_to_d3html(
+    input_file: TextIO,
+    output_file: TextIO,
+    input_fmt: str,
+    images: list | None = None,
+    forblack: bool = False,
+    template_file: TextIO | None = None,
+    hover: bool = False,
+    highlight_last_move: bool = True,
+) -> None:
+    print(f"Reading {input_file.name} and converting to d3html", file=sys.stderr)
+
+    if input_fmt == "json":
+        try:
+            data = json_mod.load(input_file)
+        except json_mod.JSONDecodeError as exc:
+            print(f"Error: {input_file.name} is not valid JSON: {exc}", file=sys.stderr)
+            sys.exit(1)
+        game = parse_json(data)
+    else:
+        game = chess.pgn.read_game(input_file)
+        if game is None:
+            print(f"Error: no valid PGN game found in {input_file.name}", file=sys.stderr)
+            sys.exit(1)
+
+    modes = frozenset(images or ["variations"])
+    template_path = pathlib.Path(template_file.name) if template_file else None
+
+    try:
+        html_str, images_dict = export_d3html(
+            game,
+            image_modes=modes,
+            board_img_for_black=forblack,
+            template_path=template_path,
+            hover=hover,
+            highlight_last_move=highlight_last_move,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(html_str, file=output_file, end="")
+
+    is_stdout = getattr(output_file, "name", "<stdout>") == "<stdout>"
+    if not is_stdout and images_dict:
+        output_dir = pathlib.Path(output_file.name).parent
+        for filename, svg_content in images_dict.items():
+            (output_dir / filename).write_text(svg_content)
+        print(
+            f"Written {len(images_dict)} SVG image(s) to {output_dir}",
+            file=sys.stderr,
+        )
+
+    print(f"Conversion to d3html done, written to {output_file.name}", file=sys.stderr)
+
+
 def cli() -> None:
     args = parse_args()
 
-    if args.template and args.format != "dothtml":
-        print("Warning: --template is only used with -f dothtml; ignoring.", file=sys.stderr)
+    if args.template and args.format not in ("dothtml", "d3html"):
+        print("Warning: --template is only used with -f dothtml or -f d3html; ignoring.", file=sys.stderr)
+
+    if args.hover and args.format != "d3html":
+        print("Warning: -a/--hover-for-all-moves is only used with -f d3html; ignoring.", file=sys.stderr)
 
     input_fmt = _detect_input_format(args.input, args.input_format)
     output_fmt = args.format
@@ -246,18 +327,29 @@ def cli() -> None:
     elif input_fmt == "json" and output_fmt == "pgn":
         json_to_pgn(args.input, args.output)
     elif input_fmt in ("pgn", "json") and output_fmt == "dot":
-        game_to_dot(args.input, args.output, input_fmt, images=args.images, forblack=args.forblack)
+        game_to_dot(args.input, args.output, input_fmt, images=args.images, forblack=args.forblack, highlight_last_move=args.highlight_last_move)
     elif input_fmt in ("pgn", "json") and output_fmt == "dothtml":
         game_to_dothtml(
             args.input, args.output, input_fmt,
             images=args.images,
             forblack=args.forblack,
             template_file=args.template,
+            highlight_last_move=args.highlight_last_move,
+        )
+    elif input_fmt in ("pgn", "json") and output_fmt == "d3html":
+        game_to_d3html(
+            args.input, args.output, input_fmt,
+            images=args.images,
+            forblack=args.forblack,
+            template_file=args.template,
+            hover=args.hover,
+            highlight_last_move=args.highlight_last_move,
         )
     else:
         print(
             f"Error: unsupported conversion: {input_fmt} → {output_fmt}. "
-            f"Supported: pgn→json, pgn→edn, pgn→dot, pgn→dothtml, json→pgn, json→dot, json→dothtml",
+            f"Supported: pgn→json, pgn→edn, pgn→dot, pgn→dothtml, pgn→d3html, "
+            f"json→pgn, json→dot, json→dothtml, json→d3html",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/chesstree/d3html_exporter.py
+++ b/chesstree/d3html_exporter.py
@@ -1,0 +1,107 @@
+"""D3HTML exporter: wraps the D3 tree JSON in an interactive HTML template."""
+from __future__ import annotations
+
+import json as json_mod
+import pathlib
+from importlib.resources import files as _pkg_files
+from typing import Optional
+
+import chess.pgn
+
+from chesstree.d3tree_exporter import export_d3tree
+from chesstree.dothtml_exporter import _escape_js_template_literal, _game_title
+
+PLACEHOLDER_TITLE = "{{CHESSTREE_TITLE}}"
+PLACEHOLDER_TREE_DATA = "{{CHESSTREE_TREE_DATA}}"
+PLACEHOLDER_IMAGES = "{{CHESSTREE_IMAGES}}"
+PLACEHOLDER_HOVER_DATA = "{{CHESSTREE_HOVER_DATA}}"
+
+_REQUIRED_PLACEHOLDERS = (
+    PLACEHOLDER_TITLE,
+    PLACEHOLDER_TREE_DATA,
+    PLACEHOLDER_IMAGES,
+    PLACEHOLDER_HOVER_DATA,
+)
+
+
+def _read_default_template() -> str:
+    return (
+        _pkg_files("chesstree.templates")
+        .joinpath("d3html_default.html")
+        .read_text(encoding="utf-8")
+    )
+
+
+def _build_hover_data_js(hover: bool, hover_images: dict[str, str]) -> str:
+    """Build the JS snippet that sets hoverEnabled and hoverImages."""
+    if not hover:
+        return "const hoverEnabled = false;\nconst hoverImages = {};"
+    safe = json_mod.dumps(hover_images)
+    return f"const hoverEnabled = true;\nconst hoverImages = {safe};"
+
+
+def export_d3html(
+    game: chess.pgn.Game,
+    image_modes: frozenset[str] = frozenset(["variations"]),
+    board_img_for_black: bool = False,
+    template_path: Optional[pathlib.Path] = None,
+    hover: bool = False,
+    highlight_last_move: bool = True,
+) -> tuple[str, dict[str, str]]:
+    """Export a chess game to an interactive D3 HTML string.
+
+    Returns ``(html_string, images)`` where ``images`` maps SVG filename to
+    SVG content.  The caller is responsible for writing the SVG files alongside
+    the HTML file so that the browser can load them.
+
+    ``template_path`` overrides the built-in template.  The template must
+    contain all four required placeholders:
+    ``{{CHESSTREE_TITLE}}``, ``{{CHESSTREE_TREE_DATA}}``,
+    ``{{CHESSTREE_IMAGES}}``, and ``{{CHESSTREE_HOVER_DATA}}``.
+    """
+    tree_dict, images, hover_images = export_d3tree(
+        game,
+        image_modes=image_modes,
+        board_img_for_black=board_img_for_black,
+        hover=hover,
+        highlight_last_move=highlight_last_move,
+    )
+
+    if template_path is not None:
+        template = template_path.read_text(encoding="utf-8")
+        template_label = str(template_path)
+    else:
+        template = _read_default_template()
+        template_label = "built-in d3html_default.html"
+
+    missing = [p for p in _REQUIRED_PLACEHOLDERS if p not in template]
+    if missing:
+        raise ValueError(
+            f"Template '{template_label}' is missing required placeholder(s): "
+            + ", ".join(missing)
+        )
+
+    title = _game_title(game)
+    tree_json = _escape_js_template_literal(json_mod.dumps(tree_dict))
+    images_js = _build_images_js(images)
+    hover_js = _build_hover_data_js(hover, hover_images)
+
+    html = template
+    html = html.replace(PLACEHOLDER_TITLE, title)
+    html = html.replace(PLACEHOLDER_TREE_DATA, tree_json)
+    html = html.replace(PLACEHOLDER_IMAGES, images_js)
+    html = html.replace(PLACEHOLDER_HOVER_DATA, hover_js)
+
+    return html, images
+
+
+def _build_images_js(images: dict[str, str]) -> str:
+    """Build a JS comment listing the image filenames (informational only).
+
+    The D3 template loads images via <img> src attributes, not via an addImage
+    call.  This placeholder is kept for template compatibility.
+    """
+    if not images:
+        return "// no board images"
+    names = ", ".join(f'"{n}"' for n in images)
+    return f"// board images: [{names}]"

--- a/chesstree/d3tree_exporter.py
+++ b/chesstree/d3tree_exporter.py
@@ -1,0 +1,351 @@
+"""D3 tree exporter: converts a chess game to a JSON tree structure for D3 rendering."""
+from __future__ import annotations
+
+from typing import Optional
+
+import chess
+import chess.pgn
+import chess.svg
+
+from chesstree.utils import (
+    NAG_TO_PGN_STRING,
+    _PGN_COMMAND_ANNOTATION_RE,
+    _ASSESSMENT_NAGS_PRIORITY,
+    _nag_symbol,
+    _node_id,
+    _last_move_fill,
+)
+
+from chess.pgn import (
+    NAG_BLUNDER,
+    NAG_BRILLIANT_MOVE,
+    NAG_DUBIOUS_MOVE,
+    NAG_GOOD_MOVE,
+    NAG_MISTAKE,
+    NAG_SPECULATIVE_MOVE,
+)
+
+_NAG_CSS_CLASSES: dict[int, str] = {
+    NAG_BLUNDER: "nag-blunder",
+    NAG_MISTAKE: "nag-mistake",
+    NAG_DUBIOUS_MOVE: "nag-dubious",
+    NAG_SPECULATIVE_MOVE: "nag-speculative",
+    NAG_GOOD_MOVE: "nag-good",
+    NAG_BRILLIANT_MOVE: "nag-brilliant",
+}
+
+
+def _nag_class(node: chess.pgn.ChildNode) -> Optional[str]:
+    for nag in _ASSESSMENT_NAGS_PRIORITY:
+        if nag in node.nags:
+            return _NAG_CSS_CLASSES[nag]
+    return None
+
+
+def _format_move_num(node: chess.pgn.ChildNode) -> str:
+    num = node.parent.board().fullmove_number
+    is_white = node.parent.board().turn == chess.WHITE
+    return f"{num}." if is_white else f"{num}\u2026"
+
+
+def _wrap_text(text: str, width: int = 32) -> list[str]:
+    """Wrap text at word boundaries, returning a list of line strings."""
+    if not text:
+        return []
+    words = text.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = (current + " " + word).lstrip()
+        if current and len(candidate) > width:
+            lines.append(current)
+            current = word
+        else:
+            current = candidate
+    if current:
+        lines.append(current)
+    return lines
+
+
+def _format_edge_label(node: chess.pgn.ChildNode) -> dict:
+    """Return a structured edge label dict with move, NAG class, and comments.
+
+    Comments are pre-wrapped into lines for direct rendering in the template.
+    """
+    num = node.parent.board().fullmove_number
+    is_white = node.parent.board().turn == chess.WHITE
+    san = node.parent.board().san(node.move)
+    nag = _nag_symbol(node)
+    nag_cls = _nag_class(node)
+    move_text = f"{num}. {san}{nag}" if is_white else f"{num}\u2026 {san}{nag}"
+
+    starting_comment = _PGN_COMMAND_ANNOTATION_RE.sub("", node.starting_comment or "").strip()
+    comment = _PGN_COMMAND_ANNOTATION_RE.sub("", node.comment or "").strip()
+
+    return {
+        "move": move_text,
+        "nagClass": nag_cls,
+        "startingComment": _wrap_text(starting_comment) if starting_comment else None,
+        "comment": _wrap_text(comment) if comment else None,
+    }
+
+
+class _D3TreeBuilder:
+    """Builds a JSON tree from a chess game for D3 rendering."""
+
+    def __init__(
+        self,
+        game: chess.pgn.Game,
+        image_modes: frozenset[str] = frozenset(["variations"]),
+        board_img_for_black: bool = False,
+        hover: bool = False,
+        highlight_last_move: bool = True,
+    ) -> None:
+        self.game = game
+        self.image_modes = image_modes
+        self.orientation = chess.BLACK if board_img_for_black else chess.WHITE
+        self.hover = hover
+        self.highlight_last_move = highlight_last_move
+        self._images: dict[str, str] = {}
+        self._hover_images: dict[str, str] = {}
+
+    def build(self) -> tuple[dict, dict[str, str], dict[str, str]]:
+        headers = self.game.headers
+        white = headers.get("White")
+        black = headers.get("Black")
+        raw_date = headers.get("UTCDate") or headers.get("Date") or None
+        date = raw_date if raw_date and "?" not in raw_date else None
+
+        if white and black and white != "?" and black != "?":
+            title = f"{white} vs {black} at {date}" if date else f"{white} vs {black}"
+        else:
+            event = headers.get("Event", "?")
+            title = f"{event} at {date}" if date else event
+
+        game_comment = _PGN_COMMAND_ANNOTATION_RE.sub("", self.game.comment or "").strip()
+
+        root = {
+            "type": "root",
+            "title": title,
+            "headers": {
+                k: v
+                for k, v in headers.items()
+                if k not in ("FEN", "SetUp")
+            },
+            "gameComment": game_comment or None,
+            "children": [],
+        }
+
+        if self.game.variations:
+            main_segments = self._collect_main_segments_flat(self.game.variations[0])
+            root["children"].extend(main_segments)
+            for alt in self.game.variations[1:]:
+                root["children"].append(
+                    self._build_variation_segment(
+                        alt, is_variation=True, edge_label=_format_edge_label(alt)
+                    )
+                )
+
+        return root, self._images, self._hover_images
+
+    def _collect_main_segments_flat(
+        self,
+        start: chess.pgn.ChildNode,
+    ) -> list[dict]:
+        """Collect all main-line segments as a flat list, each with their own
+        variation children but without chaining to the next main-line segment.
+
+        This mirrors DOT's ``_collect_main_segments`` traversal but returns a
+        flat list so that all main-line segments become direct children of the
+        root node in the tree, rather than being nested one inside the next.
+        """
+        segments: list[dict] = []
+        current_start: Optional[chess.pgn.ChildNode] = start
+
+        while current_start is not None:
+            block: list[chess.pgn.ChildNode] = []
+            branch_alternatives: list[chess.pgn.ChildNode] = []
+            next_continuation: Optional[chess.pgn.ChildNode] = None
+            current: Optional[chess.pgn.ChildNode] = current_start
+
+            while current is not None:
+                block.append(current)
+                n_vars = len(current.variations)
+                if n_vars == 0:
+                    break
+                elif n_vars > 1:
+                    branch_alternatives = list(current.variations[1:])
+                    branching_move = current.variations[0]
+                    block.append(branching_move)
+                    if branching_move.variations:
+                        next_continuation = branching_move.variations[0]
+                    break
+                else:
+                    current = current.variations[0]
+
+            moves = self._build_moves(block)
+            self._populate_move_images(block, moves)
+            hover_fens = self._build_hover_fens(block)
+
+            segment: dict = {
+                "type": "segment",
+                "isVariation": False,
+                "isMainLine": True,
+                "edgeLabel": None,
+                "moves": moves,
+                "hoverFens": hover_fens,
+                "children": [],
+            }
+
+            for alt in branch_alternatives:
+                segment["children"].append(
+                    self._build_variation_segment(
+                        alt, is_variation=True, edge_label=_format_edge_label(alt)
+                    )
+                )
+
+            segments.append(segment)
+            current_start = next_continuation
+
+        return segments
+
+    def _build_variation_segment(
+        self,
+        start: chess.pgn.ChildNode,
+        is_variation: bool,
+        edge_label: Optional[str],
+    ) -> dict:
+        """Variation segment: collects ALL moves until the line ends.
+
+        Follows ``variations[0]`` past sub-branch points, noting the
+        alternatives (``variations[1:]``) as children.  Mirrors DOT's
+        ``_collect_variation_moves`` behaviour.  Never splits at comments.
+        """
+        block: list[chess.pgn.ChildNode] = []
+        sub_variations: list[chess.pgn.ChildNode] = []
+        current: Optional[chess.pgn.ChildNode] = start
+
+        while current is not None:
+            block.append(current)
+            n_vars = len(current.variations)
+            if n_vars == 0:
+                break
+            elif n_vars > 1:
+                sub_variations.extend(current.variations[1:])
+                current = current.variations[0]
+            else:
+                current = current.variations[0]
+
+        moves = self._build_moves(block)
+        self._populate_move_images(block, moves)
+        hover_fens = self._build_hover_fens(block)
+
+        segment: dict = {
+            "type": "segment",
+            "isVariation": is_variation,
+            "isMainLine": False,
+            "edgeLabel": edge_label,
+            "moves": moves,
+            "hoverFens": hover_fens,
+            "children": [],
+        }
+
+        for alt in sub_variations:
+            segment["children"].append(
+                self._build_variation_segment(
+                    alt, is_variation=True, edge_label=_format_edge_label(alt)
+                )
+            )
+        return segment
+
+    def _build_moves(self, block: list[chess.pgn.ChildNode]) -> list[dict]:
+        moves = []
+        for node in block:
+            san = node.parent.board().san(node.move)
+            nag = _nag_symbol(node)
+            css_class = _nag_class(node)
+            fen = node.board().fen()
+            comment_raw = node.comment or ""
+            comment = _PGN_COMMAND_ANNOTATION_RE.sub("", comment_raw).strip() or None
+            moves.append(
+                {
+                    "num": _format_move_num(node),
+                    "san": san,
+                    "nag": nag or None,
+                    "nagClass": css_class,
+                    "fen": fen,
+                    "comment": comment,
+                    "image": None,
+                }
+            )
+        return moves
+
+    def _populate_move_images(
+        self,
+        block: list[chess.pgn.ChildNode],
+        moves: list[dict],
+    ) -> None:
+        """Set the ``image`` field on move dicts in-place.
+
+        Mirrors DOT's ``_block_needs_image`` logic:
+        - ``all``: image at every block boundary (commented move OR last move).
+        - ``variations``: image at the last move only.
+        - ``commented``: image at each commented move.
+        Modes combine additively.
+        """
+        if not self.image_modes or "none" in self.image_modes:
+            return
+        last_idx = len(moves) - 1
+        for i, (node, m) in enumerate(zip(block, moves)):
+            is_last = i == last_idx
+            if "all" in self.image_modes:
+                if m.get("comment") or is_last:
+                    m["image"] = self._ensure_image(node)
+            else:
+                if "variations" in self.image_modes and is_last:
+                    m["image"] = self._ensure_image(node)
+                if "commented" in self.image_modes and m.get("comment"):
+                    m["image"] = self._ensure_image(node)
+
+    def _build_hover_fens(self, block: list[chess.pgn.ChildNode]) -> dict[str, str]:
+        hover_fens: dict[str, str] = {}
+        if not self.hover:
+            return hover_fens
+        for node in block:
+            fen = node.board().fen()
+            img_key = _node_id(fen)
+            hover_fens[img_key] = fen
+            if img_key not in self._hover_images:
+                fill = _last_move_fill(node.move) if self.highlight_last_move else {}
+                self._hover_images[img_key] = chess.svg.board(
+                    node.board(), size=150, orientation=self.orientation, fill=fill
+                )
+        return hover_fens
+
+    def _ensure_image(self, node: chess.pgn.ChildNode) -> str:
+        board = node.board()
+        filename = _node_id(board.fen()) + ".svg"
+        if filename not in self._images:
+            fill = _last_move_fill(node.move) if self.highlight_last_move else {}
+            self._images[filename] = chess.svg.board(
+                board, size=250, orientation=self.orientation, fill=fill
+            )
+        return filename
+
+
+def export_d3tree(
+    game: chess.pgn.Game,
+    image_modes: frozenset[str] = frozenset(["variations"]),
+    board_img_for_black: bool = False,
+    hover: bool = False,
+    highlight_last_move: bool = True,
+) -> tuple[dict, dict[str, str], dict[str, str]]:
+    """Export a chess game as a JSON tree dict plus image dicts.
+
+    Returns ``(tree_dict, images, hover_images)`` where:
+    - ``tree_dict`` is the JSON-serialisable tree for the D3 renderer
+    - ``images`` maps SVG filename → SVG content for board position images
+    - ``hover_images`` maps node-ID → SVG content for hover board popups
+      (only populated when ``hover=True``)
+    """
+    return _D3TreeBuilder(game, image_modes, board_img_for_black, hover, highlight_last_move).build()

--- a/chesstree/dot_exporter.py
+++ b/chesstree/dot_exporter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import html
 import re
 from typing import Optional
@@ -17,19 +16,14 @@ from chess.pgn import (
     NAG_SPECULATIVE_MOVE,
 )
 
-from chesstree.json_exporter import NAG_TO_PGN_STRING
-from chesstree.utils import has_real_comment, _PGN_COMMAND_ANNOTATION_RE
-
-# Assessment NAGs ordered by priority: most severe first.
-# When a block or branch has multiple NAGs, the most severe wins for coloring.
-_ASSESSMENT_NAGS_PRIORITY = [
-    NAG_BLUNDER,
-    NAG_MISTAKE,
-    NAG_DUBIOUS_MOVE,
-    NAG_SPECULATIVE_MOVE,
-    NAG_GOOD_MOVE,
-    NAG_BRILLIANT_MOVE,
-]
+from chesstree.utils import (
+    has_real_comment,
+    _PGN_COMMAND_ANNOTATION_RE,
+    _ASSESSMENT_NAGS_PRIORITY,
+    _nag_symbol,
+    _node_id,
+    _last_move_fill,
+)
 
 _NAG_COLORS: dict[int, str] = {
     NAG_BLUNDER: "#cc2200",
@@ -41,25 +35,12 @@ _NAG_COLORS: dict[int, str] = {
 }
 
 
-def _nag_symbol(node: chess.pgn.ChildNode) -> str:
-    """Return the PGN symbol for the most significant assessment NAG on this node."""
-    for nag in _ASSESSMENT_NAGS_PRIORITY:
-        if nag in node.nags:
-            return NAG_TO_PGN_STRING[nag]
-    return ""
-
-
 def _move_color(node: chess.pgn.ChildNode) -> Optional[str]:
     """Return the highlight color for a move based on its assessment NAG, or None."""
     for nag in _ASSESSMENT_NAGS_PRIORITY:
         if nag in node.nags:
             return _NAG_COLORS[nag]
     return None
-
-
-def _node_id(fen: str) -> str:
-    """Generate a stable node ID from a FEN string."""
-    return "n" + hashlib.md5(fen.encode()).hexdigest()[:8]
 
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
@@ -144,10 +125,12 @@ class _DotBuilder:
         game: chess.pgn.Game,
         image_modes: frozenset[str] = frozenset(["variations"]),
         board_img_for_black: bool = False,
+        highlight_last_move: bool = True,
     ) -> None:
         self.game = game
         self.image_modes = image_modes
         self.orientation = chess.BLACK if board_img_for_black else chess.WHITE
+        self.highlight_last_move = highlight_last_move
         self._node_decls: list[str] = []
         self._edge_decls: list[str] = []
         self._main_seg_ids: list[str] = []
@@ -407,8 +390,9 @@ class _DotBuilder:
         board = node.board()
         filename = _node_id(board.fen()) + ".svg"
         if filename not in self._images:
+            fill = _last_move_fill(node.move) if self.highlight_last_move else {}
             self._images[filename] = chess.svg.board(
-                board, size=250, orientation=self.orientation
+                board, size=250, orientation=self.orientation, fill=fill
             )
         return filename
 
@@ -492,10 +476,11 @@ def export_dot(
     game: chess.pgn.Game,
     image_modes: frozenset[str] = frozenset(["variations"]),
     board_img_for_black: bool = False,
+    highlight_last_move: bool = True,
 ) -> tuple[str, dict[str, str]]:
     """Export a chess game to a GraphViz DOT string plus a dict of image files.
 
     Returns a tuple of (dot_string, images) where images maps filename to SVG
     content. The images dict is empty when image_modes is empty or {"none"}.
     """
-    return _DotBuilder(game, image_modes, board_img_for_black).build()
+    return _DotBuilder(game, image_modes, board_img_for_black, highlight_last_move).build()

--- a/chesstree/dothtml_exporter.py
+++ b/chesstree/dothtml_exporter.py
@@ -55,6 +55,7 @@ def export_dothtml(
     image_modes: frozenset[str] = frozenset(["variations"]),
     board_img_for_black: bool = False,
     template_path: Optional[pathlib.Path] = None,
+    highlight_last_move: bool = True,
 ) -> tuple[str, dict[str, str]]:
     """Export a chess game to a self-contained d3-graphviz HTML string.
 
@@ -66,7 +67,7 @@ def export_dothtml(
     contain the placeholders ``{{CHESSTREE_TITLE}}``, ``{{CHESSTREE_IMAGES}}``,
     and ``{{CHESSTREE_DOT}}``.
     """
-    dot_str, images = export_dot(game, image_modes=image_modes, board_img_for_black=board_img_for_black)
+    dot_str, images = export_dot(game, image_modes=image_modes, board_img_for_black=board_img_for_black, highlight_last_move=highlight_last_move)
 
     if template_path is not None:
         template = template_path.read_text(encoding="utf-8")

--- a/chesstree/json_exporter.py
+++ b/chesstree/json_exporter.py
@@ -37,7 +37,7 @@ from chess.pgn import (
 )
 from typing import Optional, List, Union, FrozenSet
 
-from chesstree.utils import has_real_comment, _PGN_COMMAND_ANNOTATION_RE
+from chesstree.utils import has_real_comment, _PGN_COMMAND_ANNOTATION_RE, NAG_TO_PGN_STRING
 
 try:
     from typing import override
@@ -125,44 +125,6 @@ def _extract_command_annotations(comment: str) -> dict:
         result["arrows"] = arrows
 
     return result
-
-
-NAG_TO_PGN_STRING = {
-    # Move assessment ($1–$6) — inline PGN symbols
-    NAG_GOOD_MOVE: "!",
-    NAG_MISTAKE: "?",
-    NAG_BRILLIANT_MOVE: "!!",
-    NAG_BLUNDER: "??",
-    NAG_SPECULATIVE_MOVE: "!?",
-    NAG_DUBIOUS_MOVE: "?!",
-    # $7: forced/only move; $8 and $9 have no standard symbol
-    NAG_FORCED_MOVE: "□",
-    # Position assessment ($10–$19)
-    # $11 (quiet) and $12 (active) have no standard symbol in the PGN spec
-    NAG_DRAWISH_POSITION: "=",       # $10
-    NAG_UNCLEAR_POSITION: "∞",       # $13
-    NAG_WHITE_SLIGHT_ADVANTAGE: "⩲", # $14
-    NAG_BLACK_SLIGHT_ADVANTAGE: "⩱", # $15
-    NAG_WHITE_MODERATE_ADVANTAGE: "±", # $16
-    NAG_BLACK_MODERATE_ADVANTAGE: "∓", # $17
-    NAG_WHITE_DECISIVE_ADVANTAGE: "+-", # $18
-    NAG_BLACK_DECISIVE_ADVANTAGE: "-+", # $19
-    # Zugzwang ($22–$23)
-    NAG_WHITE_ZUGZWANG: "⨀",         # $22
-    NAG_BLACK_ZUGZWANG: "⨀",         # $23
-    # Counterplay ($132–$135): ⇆ explicitly defined for $132; extended to all
-    NAG_WHITE_MODERATE_COUNTERPLAY: "⇆",  # $132
-    NAG_BLACK_MODERATE_COUNTERPLAY: "⇆",  # $133
-    NAG_WHITE_DECISIVE_COUNTERPLAY: "⇆",  # $134
-    NAG_BLACK_DECISIVE_COUNTERPLAY: "⇆",  # $135
-    # Time pressure ($136–$139): ⨁ explicitly defined for $138; extended to all
-    NAG_WHITE_MODERATE_TIME_PRESSURE: "⨁", # $136
-    NAG_BLACK_MODERATE_TIME_PRESSURE: "⨁", # $137
-    NAG_WHITE_SEVERE_TIME_PRESSURE: "⨁",   # $138
-    NAG_BLACK_SEVERE_TIME_PRESSURE: "⨁",   # $139
-    # Novelty
-    NAG_NOVELTY: "N",                # $146
-}
 
 
 class JsonExporter(BaseVisitor[str]):

--- a/chesstree/templates/d3html_default.html
+++ b/chesstree/templates/d3html_default.html
@@ -1,0 +1,942 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{CHESSTREE_TITLE}}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    /* -----------------------------------------------------------------------
+       Theme tokens — dark (default)
+    ----------------------------------------------------------------------- */
+    :root {
+      --bg:            #1a1a2e;
+      --chrome-bg:     #16213e;
+      --chrome-border: #0f3460;
+      --text:          #e0e0e0;
+      --text-muted:    #aaa;
+      --text-faint:    #666;
+      --text-dim:      #888;
+      --btn-bg:        #0f3460;
+      --btn-border:    #533483;
+      --btn-hover:     #533483;
+      --card-bg:       #1e3a6e;
+      --card-border:   #2a5090;
+      --card-hover-border: #533483;
+      --card-hover-shadow: #533483aa;
+      --card-drag-border:  #e94560;
+      --card-drag-shadow:  #e94560aa;
+      --card-collapsed-border: #888;
+      --root-card-bg:  #0f3460;
+      --root-card-border: #533483;
+      --var-card-bg:   #2d1f52;
+      --var-card-border: #4a3070;
+      --var-card-hover-border: #7755aa;
+      --var-card-hover-shadow: #7755aaaa;
+      --var-header-color: #b09ad0;
+      --root-title-color: #fff;
+      --root-meta-color:  #aaa;
+      --root-comment-color: #ccc;
+      --moves-color:   #d0d0d0;
+      --move-num-color: #888;
+      --comment-color: #b0b8c8;
+      --hr-color:      #0f3460;
+      --edge-label-fill: #aaa;
+      --link-main-stroke: #0f3460;
+      --link-var-stroke:  #533483;
+      --popup-border:  #533483;
+      --popup-shadow:  #0009;
+    }
+
+    /* Light theme overrides */
+    :root.light {
+      --bg:            #f0f2f5;
+      --chrome-bg:     #e0e4ed;
+      --chrome-border: #b0bcd4;
+      --text:          #1a1a2e;
+      --text-muted:    #555;
+      --text-faint:    #777;
+      --text-dim:      #666;
+      --btn-bg:        #c8d4ea;
+      --btn-border:    #7755aa;
+      --btn-hover:     #b09ad0;
+      --card-bg:       #ffffff;
+      --card-border:   #b0bcd4;
+      --card-hover-border: #7755aa;
+      --card-hover-shadow: #7755aa44;
+      --card-drag-border:  #e94560;
+      --card-drag-shadow:  #e9456044;
+      --card-collapsed-border: #aaa;
+      --root-card-bg:  #dde4f4;
+      --root-card-border: #7755aa;
+      --var-card-bg:   #f0ebfa;
+      --var-card-border: #c4add8;
+      --var-card-hover-border: #7755aa;
+      --var-card-hover-shadow: #7755aa44;
+      --var-header-color: #5a3a80;
+      --root-title-color: #1a1a2e;
+      --root-meta-color:  #555;
+      --root-comment-color: #444;
+      --moves-color:   #222;
+      --move-num-color: #777;
+      --comment-color: #445;
+      --hr-color:      #b0bcd4;
+      --edge-label-fill: #555;
+      --link-main-stroke: #8899bb;
+      --link-var-stroke:  #9977cc;
+      --popup-border:  #7755aa;
+      --popup-shadow:  #0003;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Segoe UI', system-ui, sans-serif;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 0.5rem 1rem;
+      background: var(--chrome-bg);
+      border-bottom: 1px solid var(--chrome-border);
+      flex-shrink: 0;
+    }
+
+    header h1 {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--text);
+      flex: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    header button {
+      background: var(--btn-bg);
+      border: 1px solid var(--btn-border);
+      color: var(--text);
+      padding: 0.25rem 0.65rem;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8rem;
+    }
+    header button:hover { background: var(--btn-hover); }
+
+    #tree-container {
+      flex: 1;
+      overflow: hidden;
+      position: relative;
+    }
+
+    svg#tree-svg {
+      width: 100%;
+      height: 100%;
+      cursor: grab;
+    }
+    svg#tree-svg:active { cursor: grabbing; }
+
+    /* Node cards rendered inside <foreignObject> */
+    .node-card {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 6px;
+      padding: 6px 8px;
+      font-size: 0.78rem;
+      line-height: 1.5;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      cursor: pointer;
+      transition: border-color 0.15s, box-shadow 0.15s;
+      user-select: none;
+    }
+    .node-card:hover {
+      border-color: var(--card-hover-border);
+      box-shadow: 0 0 6px var(--card-hover-shadow);
+    }
+    .node-card.collapsed {
+      border-style: dashed;
+      border-color: var(--card-collapsed-border);
+    }
+    .node-card.dragging {
+      border-color: var(--card-drag-border);
+      box-shadow: 0 0 10px var(--card-drag-shadow);
+      cursor: grabbing;
+    }
+
+    /* Root card */
+    .node-card.root-card {
+      background: var(--root-card-bg);
+      border-color: var(--root-card-border);
+    }
+
+    /* Variation card — purple tint to distinguish from main line */
+    .node-card.variation-card {
+      background: var(--var-card-bg);
+      border-color: var(--var-card-border);
+    }
+    .node-card.variation-card:hover {
+      border-color: var(--var-card-hover-border);
+      box-shadow: 0 0 6px var(--var-card-hover-shadow);
+    }
+    .node-card.variation-card .node-header {
+      color: var(--var-header-color);
+    }
+
+    .root-title { font-weight: 700; font-size: 0.85rem; color: var(--root-title-color); }
+    .root-meta  { color: var(--root-meta-color); font-size: 0.72rem; margin-top: 2px; }
+    .root-comment { font-style: italic; color: var(--root-comment-color); margin-top: 4px; font-size: 0.75rem; }
+
+    .moves-line { color: var(--moves-color); word-break: break-word; }
+    .move-num  { color: var(--move-num-color); font-size: 0.72rem; }
+
+    .nag-blunder    { color: #cc2200; font-weight: bold; }
+    .nag-mistake    { color: #e05040; font-weight: bold; }
+    .nag-dubious    { color: #e08020; }
+    .nag-speculative{ color: #f4bc4f; }
+    .nag-good       { color: #84c043; font-weight: bold; }
+    .nag-brilliant  { color: #66ccff; font-weight: bold; }
+
+    .node-comment {
+      font-style: italic;
+      color: var(--comment-color);
+      margin-top: 3px;
+      font-size: 0.74rem;
+      word-break: break-word;
+    }
+
+    .node-image {
+      display: block;
+      width: 100px;
+      height: 100px;
+      margin-top: 4px;
+    }
+
+    .node-header {
+      font-weight: 600;
+      color: var(--text-muted);
+      font-size: 0.7rem;
+      margin-bottom: 2px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .node-header .collapsed-count {
+      font-weight: normal;
+      color: var(--text-dim);
+      font-style: italic;
+    }
+    .node-card hr {
+      border: none;
+      border-top: 1px solid var(--hr-color);
+      margin: 3px 0;
+    }
+
+    /* Edge labels */
+    .edge-label {
+      font-size: 0.72rem;
+      fill: var(--edge-label-fill);
+      pointer-events: none;
+    }
+
+    /* Links */
+    .link-main {
+      fill: none;
+      stroke: var(--link-main-stroke);
+      stroke-width: 1.5px;
+    }
+    .link-variation {
+      fill: none;
+      stroke: var(--link-var-stroke);
+      stroke-width: 1.5px;
+      stroke-dasharray: 4,3;
+    }
+
+    /* Help bar */
+    #help-bar {
+      background: var(--chrome-bg);
+      border-top: 1px solid var(--chrome-border);
+      padding: 3px 1rem;
+      font-size: 0.7rem;
+      color: var(--text-faint);
+      flex-shrink: 0;
+    }
+
+    /* Hover board popup */
+    #hover-popup {
+      display: none;
+      position: fixed;
+      pointer-events: none;
+      border: 1px solid var(--popup-border);
+      border-radius: 6px;
+      overflow: hidden;
+      box-shadow: 0 4px 16px var(--popup-shadow);
+      z-index: 100;
+    }
+    #hover-popup img { display: block; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{{CHESSTREE_TITLE}}</h1>
+    <button id="btn-theme" title="Toggle light/dark theme">☀ Light</button>
+    <button id="btn-reset" title="Re-run layout (R)">↺ Reset</button>
+  </header>
+
+  <div id="tree-container">
+    <svg id="tree-svg">
+      <g id="zoom-layer">
+        <g id="links-layer"></g>
+        <g id="edge-labels-layer"></g>
+        <g id="nodes-layer"></g>
+      </g>
+    </svg>
+  </div>
+
+  <div id="help-bar">
+    Click node to collapse/expand children &nbsp;·&nbsp;
+    Drag node to reposition &nbsp;·&nbsp; ⌘/Ctrl+drag to move whole subtree &nbsp;·&nbsp;
+    Scroll to zoom &nbsp;·&nbsp; Drag background to pan &nbsp;·&nbsp; R to reset layout
+  </div>
+
+  <div id="hover-popup"><img id="hover-img" src="" alt="board"></div>
+
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <script>
+    // -----------------------------------------------------------------------
+    // Data
+    // -----------------------------------------------------------------------
+    const treeData = JSON.parse(`{{CHESSTREE_TREE_DATA}}`);
+    {{CHESSTREE_IMAGES}}
+    {{CHESSTREE_HOVER_DATA}}
+
+    // -----------------------------------------------------------------------
+    // Dimensions
+    // -----------------------------------------------------------------------
+    const NODE_WIDTH  = 210;
+    const NODE_HEIGHT_BASE = 60;   // fallback estimate per block without image
+    const IMAGE_HEIGHT = 112;       // image row height
+    const NODE_DY_MIN = 16;         // minimum vertical gap between nodes
+
+    // NAG css-class → fill color (mirrors the CSS nag-* classes for use in SVG)
+    const NAG_COLORS = {
+      "nag-blunder":     "#cc2200",
+      "nag-mistake":     "#e05040",
+      "nag-dubious":     "#e08020",
+      "nag-speculative": "#f4bc4f",
+      "nag-good":        "#84c043",
+      "nag-brilliant":   "#66ccff",
+    };
+
+    // Compute NODE_DX from the widest single edge-label line across all edges.
+    // The gap between node edges = NODE_DX - NODE_WIDTH, so label must fit in that gap.
+    // Approximation: 0.72rem font, average char ~6.5px.
+    const EDGE_LABEL_CHAR_PX = 6.5;
+    function _maxEdgeLabelChars(node) {
+      let max = 0;
+      const lbl = node.edgeLabel;
+      if (lbl) {
+        const lines = [
+          lbl.move,
+          ...(lbl.startingComment || []),
+          ...(lbl.comment || []),
+        ];
+        lines.forEach(l => { if (l.length > max) max = l.length; });
+      }
+      (node.children || []).forEach(c => {
+        const child = _maxEdgeLabelChars(c);
+        if (child > max) max = child;
+      });
+      return max;
+    }
+    const _maxLabelChars = _maxEdgeLabelChars(treeData);
+    // label_width + NODE_WIDTH + padding gives enough room between node edges
+    const NODE_DX = Math.max(280, Math.ceil(_maxLabelChars * EDGE_LABEL_CHAR_PX) + NODE_WIDTH + 40);
+
+    // Populated by measureAndInit(); used by estimateNodeHeight.
+    const measuredHeights = new Map();   // nodeKey → measured px height
+
+    function estimateNodeHeight(d) {
+      const key = nodeKey(d.data);
+      if (measuredHeights.has(key)) return measuredHeights.get(key);
+      // Fallback estimate used before measurement pass completes
+      if (d.data.type === "root") {
+        let h = 58;
+        if (d.data.gameComment) h += 18;
+        return h;
+      }
+      let h = NODE_HEIGHT_BASE;
+      const moves = d.data.moves || [];
+      const hasComment = moves.some(m => m.comment);
+      const hasImage = moves.some(m => m.image);
+      if (hasComment) h += 36;
+      if (hasImage) h += IMAGE_HEIGHT;
+      return h;
+    }
+
+    // -----------------------------------------------------------------------
+    // State
+    // -----------------------------------------------------------------------
+    let root;
+    let nodePositions = new Map();   // id → {x, y} manual overrides
+    let collapsedIds  = new Set();   // click: collapse all children
+
+    // -----------------------------------------------------------------------
+    // D3 hierarchy + layout
+    // -----------------------------------------------------------------------
+    function buildHierarchy(data) {
+      return d3.hierarchy(data, d => {
+        const key = nodeKey(d);
+        if (!d.children || !d.children.length) return null;
+        if (collapsedIds.has(key)) return null;
+        return d.children;
+      });
+    }
+
+    function nodeKey(d) {
+      // Use the first move's fen as a stable key, or root title
+      if (d.type === "root") return "root";
+      if (d.moves && d.moves.length) return d.moves[0].fen;
+      return JSON.stringify(d);
+    }
+
+    function runLayout(hierRoot) {
+      const layout = d3.tree()
+        .nodeSize([1, NODE_DX])
+        .separation((a, b) => {
+          const ha = measuredHeights.has(nodeKey(a.data))
+            ? measuredHeights.get(nodeKey(a.data))
+            : estimateNodeHeight(a);
+          const hb = measuredHeights.has(nodeKey(b.data))
+            ? measuredHeights.get(nodeKey(b.data))
+            : estimateNodeHeight(b);
+          return ha / 2 + NODE_DY_MIN + hb / 2;
+        });
+      layout(hierRoot);
+    }
+
+    // -----------------------------------------------------------------------
+    // SVG setup
+    // -----------------------------------------------------------------------
+    const svg = d3.select("#tree-svg");
+    const zoomLayer = svg.select("#zoom-layer");
+    const linksLayer = svg.select("#links-layer");
+    const edgeLabsLayer = svg.select("#edge-labels-layer");
+    const nodesLayer = svg.select("#nodes-layer");
+
+    const zoom = d3.zoom()
+      .scaleExtent([0.1, 4])
+      .filter(event => {
+        // Pan only on background (not on nodes)
+        return event.target === svg.node() ||
+               event.target.closest("#zoom-layer") === null ||
+               event.target.id === "tree-svg";
+      })
+      .on("zoom", event => {
+        zoomLayer.attr("transform", event.transform);
+      });
+
+    svg.call(zoom);
+
+    // -----------------------------------------------------------------------
+    // Rendering
+    // -----------------------------------------------------------------------
+    function render() {
+      const hierRoot = buildHierarchy(treeData);
+      runLayout(hierRoot);
+
+      // Apply manual overrides
+      hierRoot.each(d => {
+        const key = nodeKey(d.data);
+        if (nodePositions.has(key)) {
+          const pos = nodePositions.get(key);
+          d.x = pos.x;
+          d.y = pos.y;
+        }
+      });
+
+      const allNodes = hierRoot.descendants();
+      const allLinks = hierRoot.links();
+
+      // Render links
+      const linkPath = d3.linkHorizontal()
+        .x(d => d.y)
+        .y(d => d.x);
+
+      const linkSel = linksLayer.selectAll(".tree-link")
+        .data(allLinks, d => nodeKey(d.target.data));
+
+      linkSel.enter()
+        .append("path")
+        .merge(linkSel)
+        .attr("class", d =>
+          d.target.data.isVariation ? "tree-link link-variation" : "tree-link link-main"
+        )
+        .attr("d", linkPath)
+        .attr("opacity", 0)
+        .transition().duration(200)
+        .attr("opacity", 1);
+
+      linkSel.exit()
+        .transition().duration(200)
+        .attr("opacity", 0)
+        .remove();
+
+      // Edge labels
+      const edgeLabelSel = edgeLabsLayer.selectAll(".edge-label-g")
+        .data(allLinks.filter(d => d.target.data.edgeLabel), d => nodeKey(d.target.data));
+
+      const edgeLabelEnter = edgeLabelSel.enter()
+        .append("g")
+        .attr("class", "edge-label-g");
+      edgeLabelEnter.append("text").attr("class", "edge-label");
+
+      const edgeLabelMerge = edgeLabelEnter.merge(edgeLabelSel);
+      edgeLabelMerge
+        .transition().duration(200)
+        .attr("transform", d => {
+          const mx = (d.source.y + d.target.y) / 2;
+          const my = (d.source.x + d.target.x) / 2 - 4;
+          return `translate(${mx},${my})`;
+        });
+      edgeLabelMerge.select("text")
+        .attr("text-anchor", "middle")
+        .each(function(d) {
+          const lbl = d.target.data.edgeLabel;
+          const el = d3.select(this);
+          el.selectAll("tspan").remove();
+          // Build ordered list of {text, nagClass} lines
+          const lines = [];
+          (lbl.startingComment || []).forEach(l => lines.push({ text: l, nagClass: null }));
+          lines.push({ text: lbl.move, nagClass: lbl.nagClass });
+          (lbl.comment || []).forEach(l => lines.push({ text: l, nagClass: null }));
+          lines.forEach((line, i) => {
+            const ts = el.append("tspan")
+              .attr("x", 0)
+              .attr("dy", i === 0 ? "0" : "1.2em")
+              .text(line.text);
+            if (line.nagClass && NAG_COLORS[line.nagClass]) {
+              ts.attr("fill", NAG_COLORS[line.nagClass])
+                .style("font-weight", "bold");
+            }
+          });
+        });
+
+      edgeLabelSel.exit().remove();
+
+      // Nodes
+      const nodeSel = nodesLayer.selectAll(".tree-node")
+        .data(allNodes, d => nodeKey(d.data));
+
+      const nodeEnter = nodeSel.enter()
+        .append("g")
+        .attr("class", "tree-node")
+        .attr("transform", d => `translate(${d.y - NODE_WIDTH / 2},${d.x - estimateNodeHeight(d) / 2})`);
+
+      nodeEnter.each(function(d) {
+        const g = d3.select(this);
+        const h = estimateNodeHeight(d);
+        const fo = g.append("foreignObject")
+          .attr("width", NODE_WIDTH)
+          .attr("height", h);
+        fo.append("xhtml:div")
+          .attr("xmlns", "http://www.w3.org/1999/xhtml")
+          .html(buildNodeHTML(d));
+      });
+
+      // Attach interaction to entering nodes
+      nodeEnter
+        .call(makeDrag())
+        .on("click", function(event, d) {
+          // Only trigger collapse if not a drag
+          if (event.defaultPrevented) return;
+          const key = nodeKey(d.data);
+          if (d.data.type === "root") return;
+          if (!(d.data.children && d.data.children.length)) return;
+
+          if (collapsedIds.has(key)) {
+            collapsedIds.delete(key);
+          } else {
+            collapsedIds.add(key);
+          }
+          render();
+        });
+
+      // Update existing nodes
+      const nodeMerge = nodeEnter.merge(nodeSel);
+      nodeMerge.transition().duration(200)
+        .attr("transform", d => `translate(${d.y - NODE_WIDTH / 2},${d.x - estimateNodeHeight(d) / 2})`);
+
+      // Refresh HTML content (collapse state may have changed)
+      nodeMerge.each(function(d) {
+        const fo = d3.select(this).select("foreignObject");
+        const h = estimateNodeHeight(d);
+        fo.attr("height", h);
+        fo.select("div").html(buildNodeHTML(d));
+      });
+
+      nodeSel.exit()
+        .transition().duration(200)
+        .attr("opacity", 0)
+        .remove();
+    }
+
+    // -----------------------------------------------------------------------
+    // Node HTML builder
+    // -----------------------------------------------------------------------
+
+    function buildRootHTML(data) {
+      const headers = data.headers || {};
+      const event   = headers.Event  || "";
+      const site    = headers.Site   || "";
+      const eco     = headers.ECO    || "";
+      const opening = headers.Opening || "";
+      const result  = headers.Result  || "";
+      const metaParts = [event, site].filter(Boolean);
+      if (eco && eco !== "?") metaParts.push(`ECO: ${eco}`);
+      if (opening && opening !== "?") metaParts.push(opening);
+      if (result && result !== "?") metaParts.push(`Result: ${result}`);
+      let html = `<div class="node-card root-card">`;
+      html += `<div class="root-title">${esc(data.title || "")}</div>`;
+      if (metaParts.length) {
+        html += `<div class="root-meta">${esc(metaParts.join(" · "))}</div>`;
+      }
+      if (data.gameComment) {
+        html += `<div class="root-comment">${esc(data.gameComment)}</div>`;
+      }
+      html += `</div>`;
+      return html;
+    }
+
+    function segmentHeader(data, collapsedCount) {
+      const moves = data.moves || [];
+      if (!moves.length) return "";
+      const lineType = data.isMainLine ? "Main line" : "Variation";
+      const startNum = parseInt(moves[0].num);
+      const endNum   = parseInt(moves[moves.length - 1].num);
+      const range    = startNum === endNum ? `${startNum}` : `${startNum}–${endNum}`;
+      const countBadge = collapsedCount > 0
+        ? ` <span class="collapsed-count">▶ ${collapsedCount} hidden</span>`
+        : "";
+      return `<div class="node-header"><span>${lineType}: ${range}</span>${countBadge}</div><hr/>`;
+    }
+
+    // Return { collapsed, hiddenCount } for a data node
+    function collapseState(data) {
+      const key = nodeKey(data);
+      const collapsed = collapsedIds.has(key);
+      const hiddenCount = collapsed ? countDescendants(data) : 0;
+      return { collapsed, hiddenCount };
+    }
+
+    // Split a moves array into blocks ending at commented moves.
+    function splitMovesIntoBlocks(moves) {
+      const blocks = [];
+      let current = [];
+      for (const m of (moves || [])) {
+        current.push(m);
+        if (m.comment) {
+          blocks.push({ moves: current, comment: m.comment });
+          current = [];
+        }
+      }
+      if (current.length) blocks.push({ moves: current, comment: null });
+      return blocks;
+    }
+
+    function countDescendants(data) {
+      let count = 0;
+      function walk(node) {
+        (node.children || []).forEach(c => { count++; walk(c); });
+      }
+      walk(data);
+      return count;
+    }
+
+    function esc(s) {
+      return String(s)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;");
+    }
+
+    // -----------------------------------------------------------------------
+    // Drag behaviour
+    // -----------------------------------------------------------------------
+    function makeDrag() {
+      let startX, startY, origPositions, dragged, subtreeMode;
+
+      return d3.drag()
+        .on("start", function(event, d) {
+          startX = event.x;
+          startY = event.y;
+          dragged = false;
+          subtreeMode = event.sourceEvent.ctrlKey || event.sourceEvent.metaKey;
+          // Snapshot original positions of this node (and subtree if ctrl/cmd)
+          origPositions = new Map();
+          const hierRoot = buildHierarchy(treeData);
+          runLayout(hierRoot);
+          // Re-apply any existing manual overrides so origPositions are current
+          hierRoot.each(n => {
+            const k = nodeKey(n.data);
+            if (nodePositions.has(k)) {
+              const p = nodePositions.get(k);
+              n.x = p.x; n.y = p.y;
+            }
+          });
+          const draggedNode = hierRoot.descendants().find(n => nodeKey(n.data) === nodeKey(d.data));
+          if (!draggedNode) return;
+          const targets = subtreeMode ? draggedNode.descendants() : [draggedNode];
+          targets.forEach(n => origPositions.set(nodeKey(n.data), { x: n.x, y: n.y }));
+          d3.select(this).select(".node-card").classed("dragging", true);
+        })
+        .on("drag", function(event, d) {
+          const dx = event.x - startX;
+          const dy = event.y - startY;
+          if (Math.abs(dx) > 5 || Math.abs(dy) > 5) dragged = true;
+          if (!dragged) return;
+          // Apply delta to all tracked nodes
+          origPositions.forEach((orig, key) => {
+            nodePositions.set(key, { x: orig.x + dy, y: orig.y + dx });
+          });
+          // Re-render all affected node elements live
+          nodesLayer.selectAll(".tree-node")
+            .each(function(n) {
+              const k = nodeKey(n.data);
+              if (nodePositions.has(k)) {
+                const p = nodePositions.get(k);
+                n.x = p.x; n.y = p.y;
+                d3.select(this)
+                  .attr("transform", `translate(${n.y - NODE_WIDTH / 2},${n.x - estimateNodeHeight(n) / 2})`);
+              }
+            });
+          // Re-draw links and edge labels live
+          linksLayer.selectAll(".tree-link")
+            .attr("d", d3.linkHorizontal().x(n => n.y).y(n => n.x));
+          edgeLabsLayer.selectAll(".edge-label-g")
+            .attr("transform", l => {
+              const mx = (l.source.y + l.target.y) / 2;
+              const my = (l.source.x + l.target.x) / 2 - 4;
+              return `translate(${mx},${my})`;
+            });
+        })
+        .on("end", function(event, d) {
+          d3.select(this).select(".node-card").classed("dragging", false);
+          if (!dragged) {
+            // Undo all position overrides set during this drag
+            origPositions.forEach((_, key) => nodePositions.delete(key));
+          }
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Hover boards
+    // -----------------------------------------------------------------------
+    const popup  = document.getElementById("hover-popup");
+    const popImg = document.getElementById("hover-img");
+
+    document.addEventListener("mousemove", function(event) {
+      if (!hoverEnabled) return;
+      const target = event.target;
+      const nodeId = target.dataset && target.dataset.nodeid;
+      if (nodeId && hoverImages[nodeId]) {
+        const svgData = hoverImages[nodeId];
+        popImg.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svgData);
+        popImg.style.width = "150px";
+        popImg.style.height = "150px";
+        popup.style.display = "block";
+        popup.style.left = (event.clientX + 14) + "px";
+        popup.style.top  = (event.clientY + 14) + "px";
+      } else {
+        popup.style.display = "none";
+      }
+    });
+
+    function buildMovesHTML(blockMoves, hoverFens) {
+      let html = "";
+      (blockMoves || []).forEach((m, i) => {
+        const showNum = m.num.endsWith(".") || i === 0;
+        if (showNum) html += `<span class="move-num">${esc(m.num)}</span> `;
+        const nodeId = m.fen ? findNodeIdForFen(hoverFens, m.fen) : null;
+        const dataAttr = nodeId ? ` data-nodeid="${nodeId}"` : "";
+        if (m.nagClass) {
+          html += `<span class="${m.nagClass}"${dataAttr}>${esc(m.san)}${m.nag ? esc(m.nag) : ""}</span> `;
+        } else {
+          html += `<span${dataAttr}>${esc(m.san)}</span> `;
+        }
+      });
+      return html;
+    }
+
+    function findNodeIdForFen(hoverFens, fen) {
+      for (const [nodeId, f] of Object.entries(hoverFens)) {
+        if (f === fen) return nodeId;
+      }
+      return null;
+    }
+
+    function buildSegmentHTML(d, data) {
+      const { collapsed, hiddenCount } = collapseState(data);
+      let cls = "node-card";
+      if (!data.isMainLine) cls += " variation-card";
+      if (collapsed) cls += " collapsed";
+
+      let html = `<div class="${cls}">`;
+      html += segmentHeader(data, hiddenCount);
+
+      const blocks = splitMovesIntoBlocks(data.moves);
+      blocks.forEach((blk, bi) => {
+        html += `<div class="moves-line">`;
+        if (hoverEnabled) {
+          html += buildMovesHTML(blk.moves, data.hoverFens || {});
+        } else {
+          blk.moves.forEach((m, i) => {
+            const showNum = m.num.endsWith(".") || (i === 0 && bi !== 0);
+            if (showNum) html += `<span class="move-num">${esc(m.num)}</span> `;
+            if (m.nagClass) {
+              html += `<span class="${m.nagClass}">${esc(m.san)}${m.nag ? esc(m.nag) : ""}</span> `;
+            } else {
+              html += `${esc(m.san)} `;
+            }
+          });
+        }
+        html += `</div>`;
+        if (blk.comment) html += `<div class="node-comment">${esc(blk.comment)}</div>`;
+        const img = blk.moves[blk.moves.length - 1]?.image;
+        if (img) html += `<img class="node-image" src="./${esc(img)}" alt="board position">`;
+      });
+
+      html += `</div>`;
+      return html;
+    }
+
+    function buildNodeHTML(d) {
+      const data = d.data;
+      if (data.type === "root") return buildRootHTML(data);
+      return buildSegmentHTML(d, data);
+    }
+
+    // -----------------------------------------------------------------------
+    // Theme toggle
+    // -----------------------------------------------------------------------
+    const btnTheme = document.getElementById("btn-theme");
+    function applyTheme(light) {
+      if (light) {
+        document.documentElement.classList.add("light");
+        btnTheme.textContent = "🌙 Dark";
+      } else {
+        document.documentElement.classList.remove("light");
+        btnTheme.textContent = "☀ Light";
+      }
+      // Re-render so SVG fill/stroke tokens update
+      render();
+    }
+    btnTheme.addEventListener("click", function() {
+      applyTheme(!document.documentElement.classList.contains("light"));
+    });
+
+    // -----------------------------------------------------------------------
+    // Keyboard shortcuts
+    // -----------------------------------------------------------------------
+    document.addEventListener("keydown", function(e) {
+      if (e.key === "r" || e.key === "R") {
+        nodePositions.clear();
+        collapsedIds.clear();
+        measuredHeights.clear();
+        measureAndInit();
+      }
+    });
+
+    document.getElementById("btn-reset").addEventListener("click", function() {
+      nodePositions.clear();
+      collapsedIds.clear();
+      measuredHeights.clear();
+      measureAndInit();
+    });
+
+    // -----------------------------------------------------------------------
+    // Fit view helper
+    // -----------------------------------------------------------------------
+    function fitView() {
+      const container = document.getElementById("tree-container");
+      const W = container.clientWidth;
+      const H = container.clientHeight;
+
+      // Collect all node positions from the rendered DOM
+      const hierRoot = buildHierarchy(treeData);
+      runLayout(hierRoot);
+      const nodes = hierRoot.descendants();
+      if (!nodes.length) return;
+
+      const minY = d3.min(nodes, d => d.y) - NODE_WIDTH / 2;
+      const maxY = d3.max(nodes, d => d.y) + NODE_WIDTH / 2;
+      const minX = d3.min(nodes, d => d.x) - NODE_HEIGHT_BASE;
+      const maxX = d3.max(nodes, d => d.x) + NODE_HEIGHT_BASE;
+
+      const treeW = maxY - minY;
+      const treeH = maxX - minX;
+      const scale = Math.min(0.95 * W / treeW, 0.95 * H / treeH, 1.5);
+      const tx = -minY * scale + (W - treeW * scale) / 2;
+      const ty = -minX * scale + (H - treeH * scale) / 2;
+
+      svg.call(zoom.transform, d3.zoomIdentity.translate(tx, ty).scale(scale));
+    }
+
+    // -----------------------------------------------------------------------
+    // Two-pass init: measure actual node heights, then render with correct sizes
+    // -----------------------------------------------------------------------
+    function measureAndInit() {
+      const hierRoot = buildHierarchy(treeData);
+      runLayout(hierRoot);
+      const allNodes = hierRoot.descendants();
+
+      // Render nodes offscreen so the browser can calculate actual text heights.
+      const offscreen = svg.append("g")
+        .attr("id", "measure-group")
+        .attr("transform", "translate(-9999,0)");
+
+      const foMap = new Map();
+      allNodes.forEach(d => {
+        const key = nodeKey(d.data);
+        const fo = offscreen.append("foreignObject")
+          .attr("width", NODE_WIDTH)
+          .attr("height", 2000);   // tall enough to never clip
+        fo.append("xhtml:div")
+          .attr("xmlns", "http://www.w3.org/1999/xhtml")
+          .html(buildNodeHTML(d));
+        foMap.set(key, fo.node());
+      });
+
+      // Wait two animation frames so the browser has laid out the HTML.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        let maxH = NODE_HEIGHT_BASE;
+        foMap.forEach((foEl, key) => {
+          const div = foEl.querySelector("div");
+          if (div) {
+            const h = div.scrollHeight + 12;   // +12 for breathing room
+            measuredHeights.set(key, h);
+            if (h > maxH) maxH = h;
+          }
+        });
+        offscreen.remove();
+        render();
+        fitView();
+      }));
+    }
+
+    // -----------------------------------------------------------------------
+    // Initial render
+    // -----------------------------------------------------------------------
+    measureAndInit();
+  </script>
+</body>
+</html>

--- a/chesstree/utils.py
+++ b/chesstree/utils.py
@@ -1,6 +1,38 @@
 from __future__ import annotations
 
+import hashlib
 import re
+
+import chess
+import chess.pgn
+from chess.pgn import (
+    NAG_BLUNDER,
+    NAG_BRILLIANT_MOVE,
+    NAG_DUBIOUS_MOVE,
+    NAG_GOOD_MOVE,
+    NAG_MISTAKE,
+    NAG_SPECULATIVE_MOVE,
+    NAG_FORCED_MOVE,
+    NAG_DRAWISH_POSITION,
+    NAG_UNCLEAR_POSITION,
+    NAG_WHITE_SLIGHT_ADVANTAGE,
+    NAG_BLACK_SLIGHT_ADVANTAGE,
+    NAG_WHITE_MODERATE_ADVANTAGE,
+    NAG_BLACK_MODERATE_ADVANTAGE,
+    NAG_WHITE_DECISIVE_ADVANTAGE,
+    NAG_BLACK_DECISIVE_ADVANTAGE,
+    NAG_WHITE_ZUGZWANG,
+    NAG_BLACK_ZUGZWANG,
+    NAG_WHITE_MODERATE_COUNTERPLAY,
+    NAG_BLACK_MODERATE_COUNTERPLAY,
+    NAG_WHITE_DECISIVE_COUNTERPLAY,
+    NAG_BLACK_DECISIVE_COUNTERPLAY,
+    NAG_WHITE_MODERATE_TIME_PRESSURE,
+    NAG_BLACK_MODERATE_TIME_PRESSURE,
+    NAG_WHITE_SEVERE_TIME_PRESSURE,
+    NAG_BLACK_SEVERE_TIME_PRESSURE,
+    NAG_NOVELTY,
+)
 
 # Matches any PGN command annotation embedded in a comment, e.g. [%clk 0:05:00],
 # [%emt 0:00:03], [%eval 0.5], [%csl Gd4], [%cal Ge2e4].
@@ -17,3 +49,82 @@ def has_real_comment(comment: str) -> bool:
     """
     stripped = _PGN_COMMAND_ANNOTATION_RE.sub("", comment).strip()
     return bool(stripped)
+
+
+# ── NAG string mapping ───────────────────────────────────────────────────
+
+NAG_TO_PGN_STRING = {
+    # Move assessment ($1–$6) — inline PGN symbols
+    NAG_GOOD_MOVE: "!",
+    NAG_MISTAKE: "?",
+    NAG_BRILLIANT_MOVE: "!!",
+    NAG_BLUNDER: "??",
+    NAG_SPECULATIVE_MOVE: "!?",
+    NAG_DUBIOUS_MOVE: "?!",
+    # $7: forced/only move; $8 and $9 have no standard symbol
+    NAG_FORCED_MOVE: "□",
+    # Position assessment ($10–$19)
+    # $11 (quiet) and $12 (active) have no standard symbol in the PGN spec
+    NAG_DRAWISH_POSITION: "=",       # $10
+    NAG_UNCLEAR_POSITION: "∞",       # $13
+    NAG_WHITE_SLIGHT_ADVANTAGE: "⩲", # $14
+    NAG_BLACK_SLIGHT_ADVANTAGE: "⩱", # $15
+    NAG_WHITE_MODERATE_ADVANTAGE: "±", # $16
+    NAG_BLACK_MODERATE_ADVANTAGE: "∓", # $17
+    NAG_WHITE_DECISIVE_ADVANTAGE: "+-", # $18
+    NAG_BLACK_DECISIVE_ADVANTAGE: "-+", # $19
+    # Zugzwang ($22–$23)
+    NAG_WHITE_ZUGZWANG: "⨀",         # $22
+    NAG_BLACK_ZUGZWANG: "⨀",         # $23
+    # Counterplay ($132–$135): ⇆ explicitly defined for $132; extended to all
+    NAG_WHITE_MODERATE_COUNTERPLAY: "⇆",  # $132
+    NAG_BLACK_MODERATE_COUNTERPLAY: "⇆",  # $133
+    NAG_WHITE_DECISIVE_COUNTERPLAY: "⇆",  # $134
+    NAG_BLACK_DECISIVE_COUNTERPLAY: "⇆",  # $135
+    # Time pressure ($136–$139): ⨁ explicitly defined for $138; extended to all
+    NAG_WHITE_MODERATE_TIME_PRESSURE: "⨁", # $136
+    NAG_BLACK_MODERATE_TIME_PRESSURE: "⨁", # $137
+    NAG_WHITE_SEVERE_TIME_PRESSURE: "⨁",   # $138
+    NAG_BLACK_SEVERE_TIME_PRESSURE: "⨁",   # $139
+    # Novelty
+    NAG_NOVELTY: "N",                # $146
+}
+
+
+# ── Shared NAG helpers ────────────────────────────────────────────────────
+
+# Assessment NAGs ordered by priority: most severe first.
+# When a move has multiple NAGs, the most severe wins for coloring.
+_ASSESSMENT_NAGS_PRIORITY = [
+    NAG_BLUNDER,
+    NAG_MISTAKE,
+    NAG_DUBIOUS_MOVE,
+    NAG_SPECULATIVE_MOVE,
+    NAG_GOOD_MOVE,
+    NAG_BRILLIANT_MOVE,
+]
+
+
+def _nag_symbol(node: chess.pgn.ChildNode) -> str:
+    """Return the PGN symbol for the most significant assessment NAG on this node."""
+    for nag in _ASSESSMENT_NAGS_PRIORITY:
+        if nag in node.nags:
+            return NAG_TO_PGN_STRING[nag]
+    return ""
+
+
+# ── Shared node ID ────────────────────────────────────────────────────────
+
+def _node_id(fen: str) -> str:
+    """Generate a stable node ID from a FEN string."""
+    return "n" + hashlib.md5(fen.encode()).hexdigest()[:8]
+
+
+# ── Last-move highlighting ────────────────────────────────────────────────
+
+_LAST_MOVE_HIGHLIGHT_COLOR = "#d4d46a"
+
+
+def _last_move_fill(move: chess.Move) -> dict[chess.Square, str]:
+    """Return a fill dict highlighting the from/to squares of a move."""
+    return {move.from_square: _LAST_MOVE_HIGHLIGHT_COLOR, move.to_square: _LAST_MOVE_HIGHLIGHT_COLOR}

--- a/tests/sample_pgns/kramnik-karpov-1997-annotated.pgn
+++ b/tests/sample_pgns/kramnik-karpov-1997-annotated.pgn
@@ -1,0 +1,19 @@
+[Event "Dortmund Sparkassen"]
+[Site "Dortmund GER"]
+[Date "1997.07.04"]
+[Round "1"]
+[White "Vladimir Kramnik"]
+[Black "Anatoly Karpov"]
+[Result "1-0"]
+[Variant "Standard"]
+[ECO "A15"]
+[Opening "English Opening: Anglo-Indian Defense, Queen's Indian Formation"]
+[StudyName "Kramnik Games"]
+[ChapterName "Kramnik-Karpov 1997"]
+[ChapterURL "https://lichess.org/study/YEYKDn7Q/s7gH5W3v"]
+[Annotator "https://lichess.org/@/njswift"]
+
+{ This English Opening was played in Dortmund in 1997. }
+1. Nf3 Nf6 2. c4 b6 3. g3 Bb7 4. Bg2 e6 5. O-O Be7 6. Re1 O-O 7. Nc3 d5 8. cxd5 Nxd5 9. e4 Nxc3 10. bxc3 Nc6 11. d4 Na5 12. h4 Re8 { This prepares c5, because if c5 immediately then: } (12... c5? 13. d5 exd5 14. exd5 Bxd5 15. Rxe7 Qxe7 16. Qxd5 Rad8 17. Bg5) 13. h5 h6 14. Ne5 { [%cal Ge5g6,Gf7f6] } 14... Bd6 15. Bf4 { It was also possible to play Ng4: } (15. Ng4 f5 16. exf5 exf5 17. Bxb7 Nxb7 18. Rxe8+ Qxe8 19. Ne3) 15... Qe7 { [%cal Ga8e8,Ge8a8,Ge7a3] } 16. Qg4 { [%cal Gf4h6,Gg4g8] } 16... Kh8 17. Nd3 { There was also a wild double sacrifice that no human would play: } (17. Bg5 hxg5 18. Ng6+ fxg6 19. hxg6 Qd7 20. Qh5+ Kg8 21. Re3 g4 22. Qh7+ Kf8 23. Qh8+ Ke7 24. Qh4+ Kf8 25. Qxg4 Be7 26. e5 Bxg2 27. Qf4+ Bf6 28. Kxg2 Ke7 29. exf6+ gxf6 30. Rh1 Rh8 31. Rhe1 Qd5+ 32. f3 Kd7 33. Qxf6) 17... Rad8 18. Rad1 Bc6 (18... Bxf4 19. gxf4 { This would not be good for black. } { [%cal Ge1e3,Gf4f5] }) (18... c5 19. Bxd6 Qxd6 20. Ne5 { [%cal Ge5f7,Gd1d6] }) 19. e5 Ba3 20. Bxc6 Nxc6 21. Re4 { The rook defends the d pawn in case of c5 and it puts itself in position to come to the kingside in the future. } { [%cal Ge4d4,Ge4h4] } 21... Qd7?! { Black opens a line for the bishop to retreat and protect the king, but it loses time and allows white to take the initiative. } { [%csl Gf8][%cal Ga3f8] } 22. Qf3 { The queen moves so that the g pawn can advance and try to open the kingside. } { [%cal Gg3g5] } 22... Bf8 23. Be3 { Kramnik: "A rather instructive moment. The move played contains both offensive motifs, since it frees a path for the rook to the kingside along the fourth rank, as well as prophylactic ones, since the manoeuvre of the knight via e7 is not impossible. In the event of 23. g4 Ne7 24. g5 Nf5 black would have had everything in order." } { [%cal Ge4h4] } (23. g4 Ne7 24. g5 Nf5) 23... Na5 { With the bishop retreat it is not possible to play Ne7: } (23... Ne7 24. Qxf7) 24. g4 Nc4 25. g5 Nxe3 26. fxe3 { "Simpler was 26. Qxe3 hxg5 27.Qxg5 with a clear advantage to white, but I wanted to open the f file for the attack, at the same time strengthening the center." } { [%cal Gd1f1,Gf1f8,Ge3d4] } (26. Qxe3 hxg5 27. Qxg5) 26... hxg5 27. Rg4 Qe7 28. Rf1 Rd7 29. Qg3 f6 30. e4 { Kramnik: "30. h6!? was also interesting, but I did not like the fact that in the variation 30...gxh6 31. exf6 Qh7 32. Ne5 there is 32...Rd5 33.e4 Ra5, although here too white has a powerful attack." } (30. h6 gxh6 31. exf6 Qh7 32. Ne5 Rd5 33. e4 Ra5) 30... Qa3 (30... Qd8 { is passive: } 31. h6 gxh6 32. exf6 { [%cal Gd3e5,Ge5g6] }) (30... c5 { and white must play very energetically } 31. h6 cxd4 32. hxg7+ Bxg7 33. Nf4 gxf4 34. Qh4+ Kg8 35. exf6 Qf8 (35... Qd8 36. Qh6 Ree7 37. cxd4 Rf7 38. fxg7 Rxg7 39. Qxe6+ Rf7 40. Rxg7+ Kxg7 41. Qe5+ Kg8 42. Rf2) (35... Qc5 36. Kh1 Rf8 37. Rfxf4 dxc3 38. Rxg7+ Rxg7 39. fxg7 Kxg7 40. Qg3+ Kh6 41. Rh4+) 36. fxg7 Rxg7 37. Rxf4) 31. exf6 Qxc3? 32. f7 Rc8 33. d5! exd5 34. e5 c5 35. Rf3 c4 36. Nf2 Qe1+ 37. Kg2 { [%csl Gg4,Gf3,Gf2,Gg2,Gg3] } 37... Be7 38. Rxg5 Bxg5 39. f8=Q+ { 1-0 Black resigns. } 1-0
+
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import io
 import json
+import pathlib
 import sys
+import tempfile
 
 import chess.pgn
 import pytest
 
-from chesstree.cli import pgn_to_json, json_to_pgn, _detect_input_format
+from chesstree.cli import pgn_to_json, json_to_pgn, _detect_input_format, game_to_d3html
 from chesstree.json_exporter import JsonExporter
 
 SIMPLE_PGN = """\
@@ -156,3 +158,101 @@ class TestInputFormatDetection:
     def test_override_json_on_non_json_file(self):
         f = _make_input("", "data.txt")
         assert _detect_input_format(f, "json") == "json"
+
+SAMPLES = pathlib.Path(__file__).parent / "sample_pgns"
+LISPERER = SAMPLES / "lisperer_vs_verenitach.pgn"
+
+
+class TestGameToD3html:
+    def test_d3html_produces_html(self):
+        output_f = _make_output()
+        game_to_d3html(_make_input(SIMPLE_PGN, "game.pgn"), output_f, "pgn")
+        output_f.seek(0)
+        html = output_f.read()
+        assert "<!DOCTYPE html>" in html
+        assert "</html>" in html
+
+    def test_d3html_title_in_output(self):
+        output_f = _make_output()
+        game_to_d3html(_make_input(SIMPLE_PGN, "game.pgn"), output_f, "pgn")
+        output_f.seek(0)
+        html = output_f.read()
+        assert "Alice" in html
+
+    def test_d3html_tree_data_embedded(self):
+        output_f = _make_output()
+        game_to_d3html(_make_input(SIMPLE_PGN, "game.pgn"), output_f, "pgn")
+        output_f.seek(0)
+        html = output_f.read()
+        assert "JSON.parse" in html
+
+    def test_d3html_hover_disabled_by_default(self):
+        output_f = _make_output()
+        game_to_d3html(_make_input(SIMPLE_PGN, "game.pgn"), output_f, "pgn")
+        output_f.seek(0)
+        html = output_f.read()
+        assert "hoverEnabled = false" in html
+
+    def test_d3html_hover_enabled(self):
+        output_f = _make_output()
+        game_to_d3html(_make_input(SIMPLE_PGN, "game.pgn"), output_f, "pgn", hover=True)
+        output_f.seek(0)
+        html = output_f.read()
+        assert "hoverEnabled = true" in html
+
+    def test_d3html_none_images_mode(self):
+        output_f = _make_output()
+        game_to_d3html(
+            _make_input(SIMPLE_PGN, "game.pgn"), output_f, "pgn",
+            images=["none"],
+        )
+        output_f.seek(0)
+        html = output_f.read()
+        assert "<!DOCTYPE html>" in html
+
+    def test_d3html_svg_files_written_to_output_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            html_path = pathlib.Path(tmpdir) / "game.html"
+            with open(html_path, "w") as out_f:
+                game_to_d3html(
+                    _make_input(SIMPLE_PGN, "game.pgn"), out_f, "pgn",
+                    images=["all"],
+                )
+            svg_files = list(pathlib.Path(tmpdir).glob("*.svg"))
+            assert len(svg_files) > 0
+
+    def test_d3html_no_svg_on_stdout(self):
+        output_f = _make_output()  # name = "<stdout>"
+        game_to_d3html(
+            _make_input(SIMPLE_PGN, "game.pgn"), output_f, "pgn",
+            images=["all"],
+        )
+        # No SVG files should be written; just verify no error
+
+    def test_d3html_custom_template(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
+            f.write(
+                "<html><body>{{CHESSTREE_TITLE}}"
+                "{{CHESSTREE_TREE_DATA}}{{CHESSTREE_IMAGES}}"
+                "{{CHESSTREE_HOVER_DATA}}</body></html>"
+            )
+            tmp_path = pathlib.Path(f.name)
+        try:
+            output_f = _make_output()
+            template_f = open(tmp_path)
+            game_to_d3html(
+                _make_input(SIMPLE_PGN, "game.pgn"), output_f, "pgn",
+                template_file=template_f,
+            )
+            template_f.close()
+            output_f.seek(0)
+            html = output_f.read()
+            assert "Alice" in html
+        finally:
+            tmp_path.unlink()
+
+    def test_d3html_empty_pgn_exits(self):
+        output_f = _make_output()
+        with pytest.raises(SystemExit) as exc_info:
+            game_to_d3html(_make_input("", "game.pgn"), output_f, "pgn")
+        assert exc_info.value.code == 1

--- a/tests/test_d3html_exporter.py
+++ b/tests/test_d3html_exporter.py
@@ -1,0 +1,213 @@
+"""Tests for the D3HTML exporter."""
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+
+import chess.pgn
+import pytest
+
+from chesstree.d3html_exporter import (
+    PLACEHOLDER_HOVER_DATA,
+    PLACEHOLDER_IMAGES,
+    PLACEHOLDER_TITLE,
+    PLACEHOLDER_TREE_DATA,
+    _build_hover_data_js,
+    _read_default_template,
+    export_d3html,
+)
+
+SAMPLES = pathlib.Path(__file__).parent / "sample_pgns"
+LISPERER = SAMPLES / "lisperer_vs_verenitach.pgn"
+HILLBILLY = SAMPLES / "hillbilly_v3.pgn"
+
+
+def _load(path: pathlib.Path) -> chess.pgn.Game:
+    with open(path) as f:
+        return chess.pgn.read_game(f)
+
+
+# ---------------------------------------------------------------------------
+# Default template
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultTemplate:
+    def test_template_is_readable(self):
+        content = _read_default_template()
+        assert len(content) > 0
+
+    def test_template_has_all_placeholders(self):
+        content = _read_default_template()
+        assert PLACEHOLDER_TITLE in content
+        assert PLACEHOLDER_TREE_DATA in content
+        assert PLACEHOLDER_IMAGES in content
+        assert PLACEHOLDER_HOVER_DATA in content
+
+
+# ---------------------------------------------------------------------------
+# export_d3html
+# ---------------------------------------------------------------------------
+
+
+class TestExportD3html:
+    def test_returns_html_string(self):
+        html, _ = export_d3html(_load(LISPERER))
+        assert html.startswith("<!DOCTYPE html>")
+        assert "</html>" in html
+
+    def test_title_substituted(self):
+        html, _ = export_d3html(_load(LISPERER))
+        assert "lisperer" in html.lower()
+        assert PLACEHOLDER_TITLE not in html
+
+    def test_tree_data_substituted(self):
+        html, _ = export_d3html(_load(LISPERER))
+        assert "JSON.parse" in html
+        assert PLACEHOLDER_TREE_DATA not in html
+
+    def test_images_placeholder_substituted(self):
+        html, images = export_d3html(_load(LISPERER), image_modes=frozenset(["variations"]))
+        assert PLACEHOLDER_IMAGES not in html
+
+    def test_hover_data_placeholder_substituted(self):
+        html, _ = export_d3html(_load(LISPERER))
+        assert PLACEHOLDER_HOVER_DATA not in html
+
+    def test_tree_data_is_valid_json(self):
+        """Extract the JSON from the HTML and verify it parses cleanly."""
+        import re
+        html, _ = export_d3html(_load(LISPERER))
+        # The JSON is embedded as JSON.parse(`...`)
+        m = re.search(r'JSON\.parse\(`(.*?)`\)', html, re.DOTALL)
+        assert m is not None, "JSON.parse(`...`) not found in HTML"
+        # Un-escape the JS template literal escapes
+        raw = m.group(1).replace("\\`", "`").replace("\\\\", "\\").replace("\\${", "${")
+        data = json.loads(raw)
+        assert data["type"] == "root"
+
+    def test_images_dict_returned(self):
+        _, images = export_d3html(_load(LISPERER), image_modes=frozenset(["variations"]))
+        assert len(images) > 0
+
+    def test_none_mode_no_images(self):
+        _, images = export_d3html(_load(LISPERER), image_modes=frozenset(["none"]))
+        assert images == {}
+
+    def test_forblack_flag_accepted(self):
+        html, _ = export_d3html(_load(LISPERER), board_img_for_black=True,
+                                image_modes=frozenset(["variations"]))
+        assert "JSON.parse" in html
+
+    def test_hover_false_sets_flag(self):
+        html, _ = export_d3html(_load(LISPERER), hover=False)
+        assert "hoverEnabled = false" in html
+
+    def test_hover_true_sets_flag(self):
+        html, _ = export_d3html(_load(LISPERER), hover=True)
+        assert "hoverEnabled = true" in html
+
+    def test_hover_true_embeds_hover_images(self):
+        html, _ = export_d3html(_load(LISPERER), hover=True)
+        assert "hoverImages" in html
+        # The hover images dict should not be empty
+        import re
+        m = re.search(r'const hoverImages = (\{.*?\});', html, re.DOTALL)
+        assert m is not None
+        imgs = json.loads(m.group(1))
+        assert len(imgs) > 0
+
+    def test_custom_template_used(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
+            f.write(
+                "<html><head><title>{{CHESSTREE_TITLE}}</title></head>"
+                "<body>{{CHESSTREE_TREE_DATA}}{{CHESSTREE_IMAGES}}"
+                "{{CHESSTREE_HOVER_DATA}}</body></html>"
+            )
+            tmp_path = pathlib.Path(f.name)
+        try:
+            html, _ = export_d3html(_load(LISPERER), template_path=tmp_path)
+            assert "<html>" in html
+            assert "JSON.parse" not in html  # custom template has no JSON.parse
+            assert PLACEHOLDER_TITLE not in html
+            assert PLACEHOLDER_TREE_DATA not in html
+        finally:
+            tmp_path.unlink()
+
+    def test_missing_placeholder_raises(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
+            # Missing PLACEHOLDER_HOVER_DATA
+            f.write(
+                "<html>{{CHESSTREE_TITLE}}{{CHESSTREE_TREE_DATA}}"
+                "{{CHESSTREE_IMAGES}}</html>"
+            )
+            tmp_path = pathlib.Path(f.name)
+        try:
+            with pytest.raises(ValueError, match="{{CHESSTREE_HOVER_DATA}}"):
+                export_d3html(_load(LISPERER), template_path=tmp_path)
+        finally:
+            tmp_path.unlink()
+
+    def test_multiple_missing_placeholders_all_reported(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False) as f:
+            f.write("<html>only title: {{CHESSTREE_TITLE}}</html>")
+            tmp_path = pathlib.Path(f.name)
+        try:
+            with pytest.raises(ValueError) as exc_info:
+                export_d3html(_load(LISPERER), template_path=tmp_path)
+            msg = str(exc_info.value)
+            assert "{{CHESSTREE_TREE_DATA}}" in msg
+            assert "{{CHESSTREE_IMAGES}}" in msg
+            assert "{{CHESSTREE_HOVER_DATA}}" in msg
+        finally:
+            tmp_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# JS template literal escaping (tree data)
+# ---------------------------------------------------------------------------
+
+
+class TestJsEscapingInTreeData:
+    def test_backtick_in_pgn_comment_escaped(self):
+        import io
+        pgn = (
+            '[Event "Test"]\n[White "?"]\n[Black "?"]\n\n'
+            '1. e4 { `; alert("xss"); var x = ` } 1-0'
+        )
+        game = chess.pgn.read_game(io.StringIO(pgn))
+        html, _ = export_d3html(game, image_modes=frozenset(["none"]))
+        # Raw backtick injection should not appear unescaped in the JS template literal
+        assert '`; alert("xss");' not in html
+        assert "\\`" in html
+
+    def test_backslash_in_player_name_escaped(self):
+        import io
+        pgn = '[White "Alice\\\\Bob"]\n[Black "?"]\n\n1. e4 1-0'
+        game = chess.pgn.read_game(io.StringIO(pgn))
+        html, _ = export_d3html(game, image_modes=frozenset(["none"]))
+        # The title contains Alice\\Bob → should be properly escaped
+        assert html is not None
+
+
+# ---------------------------------------------------------------------------
+# _build_hover_data_js
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHoverDataJs:
+    def test_hover_disabled(self):
+        js = _build_hover_data_js(False, {})
+        assert "hoverEnabled = false" in js
+        assert "hoverImages" in js
+
+    def test_hover_enabled_with_images(self):
+        js = _build_hover_data_js(True, {"n12345678": "<svg/>"})
+        assert "hoverEnabled = true" in js
+        assert "n12345678" in js
+
+    def test_hover_enabled_empty_images(self):
+        js = _build_hover_data_js(True, {})
+        assert "hoverEnabled = true" in js
+        assert "hoverImages = {}" in js

--- a/tests/test_d3tree_exporter.py
+++ b/tests/test_d3tree_exporter.py
@@ -1,0 +1,418 @@
+"""Tests for the D3 tree exporter."""
+from __future__ import annotations
+
+import io
+import pathlib
+
+import chess
+import chess.pgn
+import pytest
+
+from chesstree.d3tree_exporter import export_d3tree, _node_id, _format_edge_label
+
+SAMPLES = pathlib.Path(__file__).parent / "sample_pgns"
+HILLBILLY = SAMPLES / "hillbilly_v3.pgn"
+LISPERER = SAMPLES / "lisperer_vs_verenitach.pgn"
+CARO_KANN = SAMPLES / "lichess_study_caro-kann-exchange-sample3.pgn"
+GERGESHAIN = SAMPLES / "gergeshain-vs-lisperer.pgn"
+
+
+def _load(path: pathlib.Path) -> chess.pgn.Game:
+    with open(path) as f:
+        return chess.pgn.read_game(f)
+
+
+def _load_pgn(pgn: str) -> chess.pgn.Game:
+    return chess.pgn.read_game(io.StringIO(pgn))
+
+
+def _all_segments(node: dict) -> list[dict]:
+    """Recursively collect all segment nodes from the tree."""
+    if node["type"] != "segment":
+        result = []
+        for child in node.get("children", []):
+            result.extend(_all_segments(child))
+        return result
+    result = [node]
+    for child in node.get("children", []):
+        result.extend(_all_segments(child))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Root node structure
+# ---------------------------------------------------------------------------
+
+
+class TestRootNode:
+    def test_root_type(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        assert tree["type"] == "root"
+
+    def test_root_has_title(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        assert "lisperer" in tree["title"].lower()
+        assert "verenitach" in tree["title"].lower()
+
+    def test_root_has_headers(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        assert "headers" in tree
+        assert "White" in tree["headers"]
+
+    def test_root_has_children(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        assert len(tree["children"]) > 0
+
+    def test_root_game_comment_none_when_no_comment(self):
+        game = chess.pgn.Game()
+        game.variations  # ensure no variations
+        tree, _, _ = export_d3tree(game)
+        assert tree["gameComment"] is None
+
+    def test_root_game_comment_present(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n{ This is a game comment. }\n1. e4 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        assert tree["gameComment"] == "This is a game comment."
+
+    def test_root_game_comment_strips_pgn_annotations(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n{ [%clk 0:05:00] Opening mistake } 1. e4 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        assert "[%clk" not in tree["gameComment"]
+        assert "Opening mistake" in tree["gameComment"]
+
+
+# ---------------------------------------------------------------------------
+# Segment structure
+# ---------------------------------------------------------------------------
+
+
+class TestSegmentStructure:
+    def test_first_child_is_segment(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        assert tree["children"][0]["type"] == "segment"
+
+    def test_segment_has_moves(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        seg = tree["children"][0]
+        assert len(seg["moves"]) > 0
+
+    def test_segment_moves_have_required_fields(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        for seg in _all_segments(tree):
+            for move in seg["moves"]:
+                assert "num" in move
+                assert "san" in move
+                assert "nag" in move
+                assert "nagClass" in move
+                assert "fen" in move
+                assert "comment" in move
+
+    def test_white_move_num_format(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n\n1. e4 e5 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        moves = _all_segments(tree)[0]["moves"]
+        assert moves[0]["num"] == "1."
+
+    def test_black_move_num_format(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n\n1. e4 e5 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        moves = _all_segments(tree)[0]["moves"]
+        assert moves[1]["num"] == "1\u2026"
+
+    def test_main_line_is_not_variation(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        assert tree["children"][0]["isVariation"] is False
+
+    def test_main_line_edge_label_is_none(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        assert tree["children"][0]["edgeLabel"] is None
+
+    def test_no_comment_move_comment_is_none(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n\n1. e4 e5 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        for m in _all_segments(tree)[0]["moves"]:
+            assert m["comment"] is None
+
+    def test_comment_stored_on_move(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n\n1. e4 { [%clk 0:05:00] Good opening } 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        seg = _all_segments(tree)[0]
+        e4_move = seg["moves"][0]
+        assert e4_move["comment"] == "Good opening"
+
+    def test_clock_only_comment_becomes_none_on_move(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n\n1. e4 { [%clk 0:05:00] } 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        seg = _all_segments(tree)[0]
+        assert seg["moves"][0]["comment"] is None
+
+
+# ---------------------------------------------------------------------------
+# Move-level comments (comments no longer split segments)
+# ---------------------------------------------------------------------------
+
+
+class TestMoveComments:
+    def test_comment_does_not_split_segment(self):
+        pgn = (
+            "[White \"A\"]\n[Black \"B\"]\n\n"
+            "1. e4 { First comment } 1... e5 2. Nf3 1-0"
+        )
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        segs = _all_segments(tree)
+        # All moves are in one main-line segment (no comment-based splitting)
+        assert len(segs) == 1
+
+    def test_comment_stored_per_move_in_segment(self):
+        pgn = (
+            "[White \"A\"]\n[Black \"B\"]\n\n"
+            "1. e4 { This is a comment } 1... e5 2. Nf3 1-0"
+        )
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        seg = _all_segments(tree)[0]
+        e4_move = seg["moves"][0]
+        assert e4_move["comment"] == "This is a comment"
+        # Remaining moves have no comment
+        for m in seg["moves"][1:]:
+            assert m["comment"] is None
+
+    def test_no_comment_no_extra_segments(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n\n1. e4 e5 2. Nf3 Nc6 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        segs = _all_segments(tree)
+        assert len(segs) == 1
+
+    def test_multiple_comments_all_in_one_segment(self):
+        pgn = (
+            "[White \"A\"]\n[Black \"B\"]\n\n"
+            "1. e4 { First } 1... e5 { Second } 2. Nf3 1-0"
+        )
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        segs = _all_segments(tree)
+        # All moves in one segment; two moves carry comments
+        assert len(segs) == 1
+        commented = [m for m in segs[0]["moves"] if m["comment"]]
+        assert len(commented) == 2
+
+
+# ---------------------------------------------------------------------------
+# Variations
+# ---------------------------------------------------------------------------
+
+
+class TestVariations:
+    def test_variation_node_is_flagged(self):
+        tree, _, _ = export_d3tree(_load(HILLBILLY))
+        all_segs = _all_segments(tree)
+        variations = [s for s in all_segs if s["isVariation"]]
+        assert len(variations) > 0
+
+    def test_variation_has_edge_label(self):
+        tree, _, _ = export_d3tree(_load(HILLBILLY))
+        all_segs = _all_segments(tree)
+        variations = [s for s in all_segs if s["isVariation"]]
+        for v in variations:
+            assert v["edgeLabel"] is not None
+            assert len(v["edgeLabel"]["move"]) > 0
+
+    def test_main_continuation_not_variation(self):
+        # First child of root is main line
+        tree, _, _ = export_d3tree(_load(HILLBILLY))
+        assert tree["children"][0]["isVariation"] is False
+
+    def test_variation_edge_label_includes_move_number(self):
+        pgn = (
+            "[White \"A\"]\n[Black \"B\"]\n\n"
+            "1. e4 (1. d4 d5) 1... e5 1-0"
+        )
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        all_segs = _all_segments(tree)
+        variations = [s for s in all_segs if s["isVariation"]]
+        assert len(variations) == 1
+        assert "1" in variations[0]["edgeLabel"]["move"]
+
+    def test_branch_point_creates_children(self):
+        pgn = (
+            "[White \"A\"]\n[Black \"B\"]\n\n"
+            "1. e4 (1. d4 d5) 1... e5 1-0"
+        )
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        all_segs = _all_segments(tree)
+        # Main segment e4+e5 + variation d4 d5 as direct children of root
+        assert len(all_segs) >= 2
+        variations = [c for c in tree["children"] if c.get("isVariation")]
+        assert len(variations) >= 1
+
+    def test_no_game_returns_empty_children(self):
+        game = chess.pgn.Game()
+        tree, images, hover = export_d3tree(game)
+        assert tree["children"] == []
+        assert images == {}
+        assert hover == {}
+
+
+# ---------------------------------------------------------------------------
+# NAG classes
+# ---------------------------------------------------------------------------
+
+
+class TestNagClasses:
+    def _make_game(self, nag: int) -> chess.pgn.Game:
+        game = chess.pgn.Game()
+        node = game.add_variation(chess.Move.from_uci("e2e4"))
+        node.nags = {nag}
+        return game
+
+    def test_blunder_nag_class(self):
+        from chess.pgn import NAG_BLUNDER
+        tree, _, _ = export_d3tree(self._make_game(NAG_BLUNDER))
+        moves = _all_segments(tree)[0]["moves"]
+        assert moves[0]["nagClass"] == "nag-blunder"
+        assert moves[0]["nag"] == "??"
+
+    def test_good_move_nag_class(self):
+        from chess.pgn import NAG_GOOD_MOVE
+        tree, _, _ = export_d3tree(self._make_game(NAG_GOOD_MOVE))
+        moves = _all_segments(tree)[0]["moves"]
+        assert moves[0]["nagClass"] == "nag-good"
+        assert moves[0]["nag"] == "!"
+
+    def test_no_nag(self):
+        pgn = "[White \"A\"]\n[Black \"B\"]\n\n1. e4 1-0"
+        tree, _, _ = export_d3tree(_load_pgn(pgn))
+        moves = _all_segments(tree)[0]["moves"]
+        assert moves[0]["nag"] is None
+        assert moves[0]["nagClass"] is None
+
+    def test_lisperer_has_nag_classes(self):
+        tree, _, _ = export_d3tree(_load(LISPERER))
+        all_segs = _all_segments(tree)
+        all_moves = [m for s in all_segs for m in s["moves"]]
+        nag_moves = [m for m in all_moves if m["nagClass"] is not None]
+        assert len(nag_moves) > 0
+
+
+# ---------------------------------------------------------------------------
+# Image modes
+# ---------------------------------------------------------------------------
+
+
+class TestImageModes:
+    def _all_move_images(self, tree) -> list[str]:
+        """Collect all non-None move image filenames across all segments."""
+        return [
+            m["image"]
+            for seg in _all_segments(tree)
+            for m in seg["moves"]
+            if m.get("image")
+        ]
+
+    def test_none_mode_no_images(self):
+        tree, images, _ = export_d3tree(_load(LISPERER), image_modes=frozenset(["none"]))
+        assert images == {}
+        assert self._all_move_images(tree) == []
+
+    def test_all_mode_every_segment_has_image(self):
+        tree, images, _ = export_d3tree(_load(LISPERER), image_modes=frozenset(["all"]))
+        assert len(images) > 0
+        # Every segment must have at least one move with an image (last move always gets one)
+        for seg in _all_segments(tree):
+            assert any(m.get("image") for m in seg["moves"])
+
+    def test_variations_mode_produces_images(self):
+        tree, images, _ = export_d3tree(_load(LISPERER), image_modes=frozenset(["variations"]))
+        assert len(images) > 0
+
+    def test_variations_mode_fewer_than_all(self):
+        _, imgs_all, _ = export_d3tree(_load(LISPERER), image_modes=frozenset(["all"]))
+        _, imgs_var, _ = export_d3tree(_load(LISPERER), image_modes=frozenset(["variations"]))
+        assert len(imgs_var) <= len(imgs_all)
+
+    def test_commented_mode_no_image_on_clock_only(self):
+        _, imgs_commented, _ = export_d3tree(
+            _load(GERGESHAIN), image_modes=frozenset(["commented"])
+        )
+        _, imgs_all, _ = export_d3tree(
+            _load(GERGESHAIN), image_modes=frozenset(["all"])
+        )
+        assert len(imgs_commented) < len(imgs_all)
+
+    def test_commented_mode_images_on_commented_moves(self):
+        pgn = (
+            "[White \"A\"]\n[Black \"B\"]\n\n"
+            "1. e4 { Good } 1... e5 2. Nf3 { Nice } 2... Nc6 1-0"
+        )
+        tree, images, _ = export_d3tree(_load_pgn(pgn), image_modes=frozenset(["commented"]))
+        seg = _all_segments(tree)[0]
+        e4_move = next(m for m in seg["moves"] if m["san"] == "e4")
+        nf3_move = next(m for m in seg["moves"] if m["san"] == "Nf3")
+        assert e4_move["image"] is not None
+        assert nf3_move["image"] is not None
+        assert len(images) > 0
+
+    def test_image_filename_in_tree_matches_images_dict(self):
+        tree, images, _ = export_d3tree(_load(LISPERER), image_modes=frozenset(["variations"]))
+        referenced = set(self._all_move_images(tree))
+        for name in referenced:
+            assert name in images
+
+    def test_empty_image_modes_no_images(self):
+        tree, images, _ = export_d3tree(_load(LISPERER), image_modes=frozenset())
+        assert images == {}
+
+
+# ---------------------------------------------------------------------------
+# Hover mode
+# ---------------------------------------------------------------------------
+
+
+class TestHoverMode:
+    def test_hover_false_empty_hover_images(self):
+        _, _, hover = export_d3tree(_load(LISPERER), hover=False)
+        assert hover == {}
+
+    def test_hover_true_populates_hover_images(self):
+        _, _, hover = export_d3tree(_load(LISPERER), hover=True)
+        assert len(hover) > 0
+
+    def test_hover_true_populates_hover_fens_in_segments(self):
+        tree, _, _ = export_d3tree(_load(LISPERER), hover=True)
+        all_segs = _all_segments(tree)
+        segs_with_hover = [s for s in all_segs if s["hoverFens"]]
+        assert len(segs_with_hover) > 0
+
+    def test_hover_fen_keys_match_hover_images(self):
+        tree, _, hover_images = export_d3tree(_load(LISPERER), hover=True)
+        all_segs = _all_segments(tree)
+        all_fen_keys = set()
+        for s in all_segs:
+            all_fen_keys.update(s["hoverFens"].keys())
+        for key in all_fen_keys:
+            assert key in hover_images
+
+    def test_hover_false_empty_hover_fens_in_segments(self):
+        tree, _, _ = export_d3tree(_load(LISPERER), hover=False)
+        for seg in _all_segments(tree):
+            assert seg["hoverFens"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Node ID stability
+# ---------------------------------------------------------------------------
+
+
+class TestNodeId:
+    def test_node_id_is_stable(self):
+        fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+        assert _node_id(fen) == _node_id(fen)
+
+    def test_node_id_different_for_different_fens(self):
+        fen1 = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+        fen2 = "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2"
+        assert _node_id(fen1) != _node_id(fen2)
+
+    def test_node_id_format(self):
+        fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"
+        nid = _node_id(fen)
+        assert nid.startswith("n")
+        assert len(nid) == 9  # 'n' + 8 hex chars

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -410,3 +410,81 @@ class TestGergeshainLisperer:
         assert len(images_commented) < len(images_all), (
             f"commented mode ({len(images_commented)}) should produce fewer DOT SVGs than all mode ({len(images_all)})"
         )
+
+
+# ---------------------------------------------------------------------------
+# D3HTML output: functional tests
+# ---------------------------------------------------------------------------
+
+from chesstree.d3html_exporter import export_d3html
+
+
+class TestD3htmlFunctional:
+    """End-to-end tests for the d3html output format using real PGN samples."""
+
+    def test_hillbilly_produces_html(self):
+        game = _load_game(HILLBILLY)
+        html, _ = export_d3html(game)
+        assert "<!DOCTYPE html>" in html
+        assert "</html>" in html
+
+    def test_lisperer_produces_html(self):
+        game = _load_game(LISPERER)
+        html, _ = export_d3html(game)
+        assert "<!DOCTYPE html>" in html
+
+    def test_caro_kann_produces_html(self):
+        game = _load_game(CARO_KANN)
+        html, _ = export_d3html(game)
+        assert "<!DOCTYPE html>" in html
+
+    def test_d3js_cdn_reference_present(self):
+        game = _load_game(LISPERER)
+        html, _ = export_d3html(game)
+        assert "d3js.org" in html
+
+    def test_tree_data_is_valid_json(self):
+        import re
+        game = _load_game(LISPERER)
+        html, _ = export_d3html(game)
+        m = re.search(r'JSON\.parse\(`(.*?)`\)', html, re.DOTALL)
+        assert m is not None, "JSON.parse(`...`) not found in HTML"
+        raw = m.group(1).replace("\\`", "`").replace("\\\\", "\\").replace("\\${", "${")
+        data = json.loads(raw)
+        assert data["type"] == "root"
+        assert len(data["children"]) > 0
+
+    def test_variations_mode_produces_svg_images(self):
+        game = _load_game(HILLBILLY)
+        _, images = export_d3html(game, image_modes=frozenset(["variations"]))
+        assert len(images) > 0
+        for name, content in images.items():
+            assert name.endswith(".svg")
+            assert "<svg" in content
+
+    def test_none_mode_produces_no_images(self):
+        game = _load_game(HILLBILLY)
+        _, images = export_d3html(game, image_modes=frozenset(["none"]))
+        assert images == {}
+
+    def test_all_mode_produces_more_images_than_variations(self):
+        game = _load_game(LISPERER)
+        _, imgs_all = export_d3html(game, image_modes=frozenset(["all"]))
+        _, imgs_var = export_d3html(game, image_modes=frozenset(["variations"]))
+        assert len(imgs_all) >= len(imgs_var)
+
+    def test_hover_mode_embeds_hover_data(self):
+        game = _load_game(LISPERER)
+        html, _ = export_d3html(game, hover=True)
+        assert "hoverEnabled = true" in html
+        assert "hoverImages" in html
+
+    def test_gergeshain_clock_annotations_not_in_output(self):
+        game = _load_game(GERGESHAIN)
+        html, _ = export_d3html(game, image_modes=frozenset(["none"]))
+        assert "[%clk" not in html
+
+    def test_gergeshain_game_comment_in_output(self):
+        game = _load_game(GERGESHAIN)
+        html, _ = export_d3html(game, image_modes=frozenset(["none"]))
+        assert "opening mistake" in html


### PR DESCRIPTION
- New d3html format (-f d3html): self-contained D3.js v7 tree viewer with dark and light theme, no GraphViz dependency
- Main-line nodes (blue) visually distinct from variation nodes (purple)
- Node headers show line type and move range (e.g. 'Main line: 1–12')
- Click collapses children only
- Hover board images on all moves via -a/--hover-for-all-moves flag
- Two-pass DOM measurement for correct node sizing
- README updated with d3html format, CLI options, and template placeholders
- Node spacing uses per-pair separation based on actual measured heights, replacing the uniform globalNodeSizeY driven by the tallest node
- Light/dark theme toggle added; all colours extracted to CSS custom properties; dark is the default, light is available via header button
- Highlight from/to squares on board images using a muted yellow (#d4d46a) by default for dot, dothtml, and d3html formats; add --no-move-highlight CLI flag to disable
- Document --no-move-highlight in README